### PR TITLE
[CAZ-1557] Handle verification link

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
     - 'config/environments/*.rb'
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/app/api_wrappers/accounts_api.rb
+++ b/app/api_wrappers/accounts_api.rb
@@ -21,5 +21,9 @@ class AccountsApi
         admin: true
       )
     end
+
+    def verify_user(_account_id:, _user_id:)
+      true
+    end
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -88,6 +88,28 @@ class OrganisationsController < ApplicationController
   end
 
   ##
+  # Checks the verification token.
+  # If the token is valid it calls backend to mark the email address as verified
+  # and redirects to :email_verified
+  # If verification fails it redirects to :verification_failed
+  #
+  # ==== Path
+  #
+  #    :GET /fleets/organisation-account/email-verification
+  #
+  # ==== Params
+  # * +token+ - string, encrypted token with verification data
+  #
+  def email_verification
+    path = if VerifyAccount.call(token: params[:token])
+             email_verified_path
+           else
+             verification_failed_path
+           end
+    redirect_to path
+  end
+
+  ##
   # Renders the email verified page.
   #
   # ==== Path
@@ -95,8 +117,18 @@ class OrganisationsController < ApplicationController
   #    :GET /fleets/organisation-account/email-verified
   #
   def email_verified
-    # TODO: Verify if user is activated.
     @user = User.new
+  end
+
+  ##
+  # Renders the error page if verification fails.
+  #
+  # ==== Path
+  #
+  #    :GET /fleets/organisation-account/verification-failed
+  #
+  def verification_failed
+    # Renders static page
   end
 
   private

--- a/app/forms/email_and_password_form.rb
+++ b/app/forms/email_and_password_form.rb
@@ -23,14 +23,9 @@ class EmailAndPasswordForm < BaseForm
     message: I18n.t('input_form.errors.invalid_format')
   }
 
-  # validates password and password_confirmation complexity
-  validates :password, :password_confirmation, format: {
-    with: /\A(?=.*?[A-Z])(?=.*?[a-z])(?=(.*[\W])+)(?!.*\s).{8,45}\z/,
-    message: I18n.t('input_form.errors.password_complexity')
-  }
-
   # validates +password+ and +password_confirmation+
   validate :correct_password_confirmation
+
   # validates +email+ and +email_confirmation+
   validate :correct_email_confirmation
 

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -59,13 +59,6 @@ class CreateAccount < BaseService
   #
   # It raises BaseApi::Error500Exception if it fails.
   def send_verification_email(user)
-    message_id = Sqs::VerificationEmail.call(user: user, host: host)
-    return if message_id
-
-    raise BaseApi::Error500Exception.new(
-      500,
-      'SQS unavailable',
-      message: I18n.t('verification_email.error')
-    )
+    Sqs::VerificationEmail.call(user: user, host: host)
   end
 end

--- a/app/services/encryption/decrypt.rb
+++ b/app/services/encryption/decrypt.rb
@@ -9,9 +9,14 @@ module Encryption
   #    Encryption::Decrypt.call(value: encrypted_token)
   #    # { user_id: 5 }
   #
+  # ==== Exceptions
+  #
+  # Raises ActiveSupport::MessageEncryptor::InvalidMessage when +value+ is nil or decryption fails.
   class Decrypt < Base
     # Instance level .call method used by class level .call
     def call
+      raise ActiveSupport::MessageEncryptor::InvalidMessage if value.nil?
+
       encryptor.decrypt_and_verify(value)
     end
   end

--- a/app/services/sqs/base.rb
+++ b/app/services/sqs/base.rb
@@ -39,7 +39,7 @@ module Sqs
       id
     rescue Aws::SQS::Errors::ServiceError => e
       log_error(e)
-      false
+      raise_service_unavailable
     end
 
     private
@@ -75,6 +75,14 @@ module Sqs
     # Return string, eg. "test@example.com-131500"
     def reference
       "#{email}-#{Time.current.strftime('%H%M%S')}"
+    end
+
+    def raise_service_unavailable
+      raise BaseApi::Error500Exception.new(
+        503,
+        'SQS unavailable',
+        message: I18n.t('email.sqs_error')
+      )
     end
   end
 end

--- a/app/services/sqs/verification_email.rb
+++ b/app/services/sqs/verification_email.rb
@@ -34,7 +34,7 @@ module Sqs
       link_params = { host: host, token: encrypted_token }
       # Adding port for development ENV
       link_params[:port] = 3000 if Rails.env.development?
-      { link: email_verified_url(link_params) }
+      { link: email_verification_url(link_params) }
     end
 
     # Generates token used to identify user after clicking link in the email

--- a/app/services/verify_account.rb
+++ b/app/services/verify_account.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+##
+# Service used to verify account, call verify endpoint in the backend API
+#
+# ==== Usage
+#    VerifyAccount.call(token: params[:token])
+#
+class VerifyAccount < BaseService
+  # Initializer method used by class level +.call+ method
+  #
+  # ==== Attributes
+  # * +token+ - string, encrypted token containing user related information like +user_id+
+  #
+  def initialize(token:)
+    @encrypted_token = token
+  end
+
+  # Execution method used by class level +.call+ method.
+  # It decrypts the token and performs API call.
+  #
+  # It return true if both actions were successful, and false if something fails.
+  #
+  def call
+    verify_user
+    true
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    Rails.logger.error "[#{self.class.name}] Invalid token - #{encrypted_token}"
+    false
+  rescue ApiException => e
+    log_error(e)
+    false
+  end
+
+  private
+
+  # Performs the API call to verification endpoint
+  def verify_user
+    AccountsApi.verify_user(
+      _account_id: decrypted_token[:account_id],
+      _user_id: decrypted_token[:user_id]
+    )
+  end
+
+  # Decrypts the token
+  def decrypted_token
+    @decrypted_token ||= Encryption::Decrypt.call(value: encrypted_token)
+  end
+
+  # Reader function for encrypted token
+  attr_reader :encrypted_token
+end

--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -7,14 +7,15 @@
   %ul#navigation.govuk-header__navigation{'aria-label': 'Top Level Navigation'}
     - if user_signed_in?
       %li.govuk-header__navigation-item{class: current_path?(authenticated_root_path)}
-        %a.govuk-header__link{href: authenticated_root_path, id: 'home'}
-          Home
+        = link_to('Home', authenticated_root_path, class: 'govuk-header__link', id: 'home')
       %li.govuk-header__navigation-item{class: current_path?('#')}
-        %a.govuk-header__link{href: '#', id: 'account'}
-          Account
-    %li.govuk-header__navigation-item{class: current_path?(new_user_session_path)}
-      - if user_signed_in?
+        = link_to('Account', '#', class: 'govuk-header__link', id: 'account')
+      %li.govuk-header__navigation-item
         = link_to('Sign Out', destroy_user_session_path,
           method: :delete, class: 'govuk-header__link', id: 'sign-out')
-      - else
+    - else
+      %li.govuk-header__navigation-item{class: current_path?(new_user_session_path)}
         = link_to('Sign In', new_user_session_path, class: 'govuk-header__link', id: 'sign-in')
+      %li.govuk-header__navigation-item{class: current_path?( create_account_name_path)}
+        = link_to('Create account', create_account_name_path, class: 'govuk-header__link', id: 'new-account')
+

--- a/app/views/organisations/email_sent.html.haml
+++ b/app/views/organisations/email_sent.html.haml
@@ -5,16 +5,14 @@
     .govuk-grid-column-two-thirds
       %h1.govuk-heading-l Verification email
       %p
-        We've sent a verification email to example@email.com. This can take a few minutes to arrive.
+        We've sent a verification email to
+        = succeed '.' do
+          = @email
+        This can take a few minutes to arrive.
 
       %p If you do not get an email:
       %ul.govuk-list.govuk-list--bullet
         %li check your spam or junk folders
         %li check you have entered the correct email
         %li
-          = link_to("resend the email", email_sent_path)
-
-      %br
-      %br
-      %p
-        = link_to("For demonstration purposes", email_verified_path)
+          = link_to("resend the email", resend_email_path)

--- a/app/views/organisations/verification_failed.html.haml
+++ b/app/views/organisations/verification_failed.html.haml
@@ -1,0 +1,7 @@
+%main.govuk-main-wrapper#main-content{role: 'main'}
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-xl [TBA] Your account verification failed
+      %p
+        [TBA] The fleets portal was unable to verify your account.
+        Please contact the support team.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,8 +20,7 @@ en:
   email:
     errors:
       email_equality: '[TBA] Email address and email address confirmation must be the same'
-  verification_email:
-    error: 'There was an error while sending Verification Email to SQS'
+    sqs_error: 'There was an error while sending the email to SQS'
   company_name:
     errors:
       summary: '[TBA] Enter the company name'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
     get 'email-sent', to: 'organisations#email_sent'
     get 'email-verified', to: 'organisations#email_verified'
+    get 'email-verification', to: 'organisations#email_verification'
+    get 'verification-failed', to: 'organisations#verification_failed'
 
     get 'add-users', to: 'users#new'
     post 'add-users', to: 'users#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     post 'email-address-and-password', to: 'organisations#create_account'
 
     get 'email-sent', to: 'organisations#email_sent'
+    get 'resend-email', to: 'organisations#resend_email'
     get 'email-verified', to: 'organisations#email_verified'
     get 'email-verification', to: 'organisations#email_verification'
     get 'verification-failed', to: 'organisations#verification_failed'

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -14,6 +14,9 @@ Feature: Organisations
       And I press the Continue
     Then I should see "Verification email"
       And I should receive verification email
+    Then I press "resend the email" link
+      And I should see "Verification email"
+      And I should receive verification email again
 
   Scenario: User wants to verify account with valid token
     Given I visit the verification link with a valid token

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -15,7 +15,11 @@ Feature: Organisations
     Then I should see "Verification email"
       And I should receive verification email
 
-  Scenario: View email verified page
-    Given I am on the root page
-    When I go to the email verified page
-    Then I should see "Your account has been created"
+  Scenario: User wants to verify account with valid token
+    Given I visit the verification link with a valid token
+    Then I should see "Your email address has been verified and your account has been activated."
+
+  Scenario: User wants to verify account with invalid token
+    Given I visit the verification link with an invalid token
+    Then I should see "Your account verification failed"
+    

--- a/features/step_definitions/organisations_steps.rb
+++ b/features/step_definitions/organisations_steps.rb
@@ -5,6 +5,16 @@ Given('I go to the create account page') do
   visit create_account_name_path
 end
 
+Given('I visit the verification link with a valid token') do
+  allow(VerifyAccount).to receive(:call).and_return(true)
+  visit email_verification_path(token: SecureRandom.uuid)
+end
+
+Given('I visit the verification link with an invalid token') do
+  allow(VerifyAccount).to receive(:call).and_return(false)
+  visit email_verification_path(token: SecureRandom.uuid)
+end
+
 Then('I enter a company name') do
   fill_in('organisations_company_name', with: 'Company name')
 end

--- a/features/step_definitions/organisations_steps.rb
+++ b/features/step_definitions/organisations_steps.rb
@@ -33,3 +33,7 @@ end
 Then('I should receive verification email') do
   expect(Sqs::VerificationEmail).to have_received(:call)
 end
+
+Then('I should receive verification email again') do
+  expect(Sqs::VerificationEmail).to have_received(:call).twice
+end

--- a/features/support/sign_in_helper.rb
+++ b/features/support/sign_in_helper.rb
@@ -19,7 +19,7 @@ module SignInHelper
 
   def new_user(options = {})
     User.new(
-      email: options[:email] || 'test@exaple.com',
+      email: options[:email] || 'test@example.com',
       admin: options[:admin] || false,
       user_id: options[:user_id] || SecureRandom.uuid,
       account_id: options[:account_id] || SecureRandom.uuid,

--- a/spec/forms/email_and_password_form_spec.rb
+++ b/spec/forms/email_and_password_form_spec.rb
@@ -89,19 +89,6 @@ RSpec.describe EmailAndPasswordForm, type: :model do
       end
     end
 
-    context 'when password not meet complexity of the criteria' do
-      let(:password) { 'Abcdefg12345' }
-
-      it { is_expected.not_to be_valid }
-
-      it 'has a proper error message' do
-        form.valid?
-        expect(form.errors.messages[:password]).to include(
-          I18n.t('input_form.errors.password_complexity', attribute: 'Password')
-        )
-      end
-    end
-
     context 'when password is too long' do
       let(:password) { '8NAOTpMkx2%9' * 4 }
 

--- a/spec/requests/organisations_controller/email_sent_spec.rb
+++ b/spec/requests/organisations_controller/email_sent_spec.rb
@@ -5,12 +5,24 @@ require 'rails_helper'
 RSpec.describe 'OrganisationsController - GET #email_sent' do
   subject { get email_sent_path }
 
+  let(:session_data) do
+    { company_name: 'Company name', new_account: create_user.serializable_hash }
+  end
+
   before do
-    add_to_session(company_name: 'Company name')
+    add_to_session(session_data)
     subject
   end
 
   it 'returns an ok response' do
     expect(response).to have_http_status(:ok)
+  end
+
+  context 'without new_account data in the session' do
+    let(:session_data) { { company_name: 'Company name' } }
+
+    it 'returns a redirect' do
+      expect(response).to redirect_to(root_path)
+    end
   end
 end

--- a/spec/requests/organisations_controller/email_verification_spec.rb
+++ b/spec/requests/organisations_controller/email_verification_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OrganisationsController - GET #email_verification' do
+  subject { get email_verification_path(token: token) }
+
+  let(:token) { 'aaaaaa' }
+
+  before { allow(VerifyAccount).to receive(:call).and_return(true) }
+
+  it 'returns a redirect to :email_verified' do
+    subject
+    expect(response).to redirect_to(email_verified_path)
+  end
+
+  it 'calls VerifyAccount with proper params' do
+    expect(VerifyAccount).to receive(:call).with(token: token)
+    subject
+  end
+
+  context 'when verification is unsuccessful' do
+    before { allow(VerifyAccount).to receive(:call).and_return(false) }
+
+    it 'returns a redirect to :verification_failed' do
+      subject
+      expect(response).to redirect_to(verification_failed_path)
+    end
+  end
+end

--- a/spec/requests/organisations_controller/resend_email_spec.rb
+++ b/spec/requests/organisations_controller/resend_email_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OrganisationsController - GET #resend_email' do
+  subject { get resend_email_path }
+
+  let(:user) { create_user }
+  let(:session_data) do
+    { company_name: 'Company name', new_account: user.serializable_hash }
+  end
+
+  before do
+    allow(Sqs::VerificationEmail).to receive(:call).and_return(SecureRandom.uuid)
+    add_to_session(session_data)
+  end
+
+  it 'returns a redirect to email_sent' do
+    subject
+    expect(response).to redirect_to(email_sent_path)
+  end
+
+  it 'calls Sqs::VerificationEmail with proper data' do
+    # This is not the same instance of user as it was serialized
+    expect(Sqs::VerificationEmail)
+      .to receive(:call)
+      .with(user: instance_of(User), host: root_url)
+    subject
+  end
+
+  context 'without new_account data in the session' do
+    let(:session_data) { { company_name: 'Company name' } }
+
+    it 'returns a redirect to root_path' do
+      subject
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/organisations_controller/verification_failed_spec.rb
+++ b/spec/requests/organisations_controller/verification_failed_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OrganisationsController - GET #verification_failed' do
+  subject { get verification_failed_path }
+
+  it 'returns an ok response' do
+    subject
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -49,14 +49,4 @@ describe CreateAccount do
       )
     service
   end
-
-  context 'when SQS call fails' do
-    before do
-      allow(Sqs::VerificationEmail).to receive(:call).and_return(false)
-    end
-
-    it 'raises API 500 Exception' do
-      expect { service }.to raise_error(BaseApi::Error500Exception)
-    end
-  end
 end

--- a/spec/services/encryption/decrypt_spec.rb
+++ b/spec/services/encryption/decrypt_spec.rb
@@ -11,4 +11,20 @@ describe Encryption::Decrypt do
   it 'decrypts message' do
     expect(service).to eq(value)
   end
+
+  context 'when token is nil' do
+    let(:token) { nil }
+
+    it 'raises ActiveSupport::MessageEncryptor::InvalidMessage' do
+      expect { service }.to raise_error(ActiveSupport::MessageEncryptor::InvalidMessage)
+    end
+  end
+
+  context 'when token is invalid' do
+    let(:token) { 'aaaaaaaaaa' }
+
+    it 'raises ActiveSupport::MessageEncryptor::InvalidMessage' do
+      expect { service }.to raise_error(ActiveSupport::MessageEncryptor::InvalidMessage)
+    end
+  end
 end

--- a/spec/services/encryption/encrypt_spec.rb
+++ b/spec/services/encryption/encrypt_spec.rb
@@ -10,4 +10,12 @@ describe Encryption::Encrypt do
   it 'returns a string' do
     expect(service).to be_a(String)
   end
+
+  context 'when value is nil' do
+    let(:value) { nil }
+
+    it 'returns a string' do
+      expect(service).to be_a(String)
+    end
+  end
 end

--- a/spec/services/sqs/verification_email_spec.rb
+++ b/spec/services/sqs/verification_email_spec.rb
@@ -28,8 +28,8 @@ describe Sqs::VerificationEmail do
         )
       end
 
-      it 'returns false' do
-        expect(service).to be_falsey
+      it 'raises API 500 Exception' do
+        expect { service }.to raise_error(BaseApi::Error500Exception)
       end
     end
   end

--- a/spec/services/verify_account_spec.rb
+++ b/spec/services/verify_account_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VerifyAccount do
+  subject(:service) { described_class.call(token: token) }
+
+  let(:token) do
+    Encryption::Encrypt.call(value: {
+                               user_id: user_id,
+                               account_id: account_id,
+                               created_at: Time.current.iso8601,
+                               salt: SecureRandom.uuid
+                             })
+  end
+  let(:user_id) { SecureRandom.uuid }
+  let(:account_id) { SecureRandom.uuid }
+
+  before { allow(AccountsApi).to receive(:verify_user).and_return(true) }
+
+  it { is_expected.to be_truthy }
+
+  it 'calls AccountsApi.verify_user with proper params' do
+    expect(AccountsApi)
+      .to receive(:verify_user)
+      .with(_user_id: user_id, _account_id: account_id)
+    service
+  end
+
+  context 'when token is nil' do
+    let(:token) { nil }
+
+    it { is_expected.to be_falsey }
+
+    it 'does not call AccountsApi.verify_user' do
+      expect(AccountsApi).not_to receive(:verify_user)
+      service
+    end
+  end
+
+  context 'when token is invalid' do
+    let(:token) { 'aaaaa' }
+
+    it { is_expected.to be_falsey }
+
+    it 'does not call AccountsApi.verify_user' do
+      expect(AccountsApi).not_to receive(:verify_user)
+      service
+    end
+  end
+
+  context 'when API responds with an error' do
+    before do
+      allow(AccountsApi)
+        .to receive(:verify_user)
+        .and_raise(BaseApi::Error404Exception.new(404, 'User ot found', {}))
+    end
+
+    it { is_expected.to be_falsey }
+  end
+end

--- a/spec/support/user_factory.rb
+++ b/spec/support/user_factory.rb
@@ -7,7 +7,7 @@ module UserFactory
 
   def create_user(options = {})
     User.new(
-      email: options[:email] || 'test@exaple.com',
+      email: options[:email] || 'test@example.com',
       admin: options[:admin] || false,
       user_id: options[:user_id] || SecureRandom.uuid,
       account_id: options[:account_id] || SecureRandom.uuid,


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1557

## Description
<!--- Describe your changes in detail -->
Added handling link `http://localhost:3000/fleets/organisation-account/email-verification?token=:token`
When the token is valid it redirects to email verified page, if not it redirects to the custom error page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As emails are not being delivered - use the link from logs from `Sqs::VerificationEmail`.
To check the invalid token, remove some parts of the token. Remember that it can't end with a % sign.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to a issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
