### PR TITLE
[CAZ-1285] Hide create account button only on create account and new credentials pages

### DIFF
--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -16,7 +16,6 @@
     - else
       %li.govuk-header__navigation-item{class: current_path?(new_user_session_path)}
         = link_to('Sign In', new_user_session_path, class: 'govuk-header__link', id: 'sign-in')
-      - if Rails.env.development?
-        %li.govuk-header__navigation-item{class: current_path?(organisations_path)}
-          = link_to('Create account', organisations_path, class: 'govuk-header__link', id: 'new-account')
+      %li.govuk-header__navigation-item{class: current_path?(organisations_path) || current_path?(new_credentials_organisations_path)}
+        = link_to('Create account', organisations_path, class: 'govuk-header__link', id: 'new-account')
 

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -7,11 +7,13 @@ Feature: Organisations
   Scenario: User wants to create a company
     Given I go to the create account page
       And I should see "Create account"
+      And I should see "Create account" link
     Then I press the Continue
       And I should see "[TBA] Company name is required"
     Then I enter a company name
       And I press the Continue
       And I should see "Account details"
+      And I should see "Create account" link
     Then I press the Continue
       And I should see "[TBA] Email is required"
       And I should see "[TBA] Password is required"

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -12,6 +12,7 @@ Feature: Sign In
     Then I should enter valid credentials and press the Continue
     When I should see "Your fleet account"
       And Cookie is created for my session
+      And I should not see "Create account" link
 
   Scenario: View dashboard page with cookie that has not expired
     Given I have authentication cookie that has not expired
@@ -28,6 +29,7 @@ Feature: Sign In
 
   Scenario: Sign in with invalid credentials
     Given I am on the Sign in page
+      And I should see "Create account" link
     When I enter invalid credentials
     Then I remain on the current page
       And I should see "[TBA] The email or password you entered is incorrect"


### PR DESCRIPTION
<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->
[JIRA](https://eaflood.atlassian.net/browse/CAZ-1285)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![2](https://user-images.githubusercontent.com/24584219/71156505-6a022c00-2240-11ea-8a9f-dd5d82ba1964.png)
![1](https://user-images.githubusercontent.com/24584219/71156507-6a022c00-2240-11ea-9461-a4b6e5f5e64f.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to a issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
