### PR TITLE
[CAZ-1834] Add redis session store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ S3_AWS_ACCESS_KEY_ID=
 S3_AWS_BUCKET=
 S3_AWS_SECRET_ACCESS_KEY=
 S3_AWS_REGION=
+
+# Redis configuration
+REDIS_URL=redis://someserver.com:6379/1

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'haml'
 gem 'httparty'
 gem 'logstash-logger'
 gem 'puma'
+gem 'redis'
 gem 'rubocop-rails'
 gem 'sass-rails'
 gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rdoc (6.2.1)
+    redis (4.1.3)
     regexp_parser (1.6.0)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -385,6 +386,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 6.0.2)
   rails-controller-testing
+  redis
   rspec-rails
   rubocop-rails
   sass-rails

--- a/app/api_wrappers/fleets_api.rb
+++ b/app/api_wrappers/fleets_api.rb
@@ -58,12 +58,17 @@ class FleetsApi < AccountsApi
       {
         'vehicleId' => SecureRandom.uuid,
         'vrn' => details[:vrn],
-        'type' => details[:type] || ComplianceCheckerApi.vehicle_details(details[:vrn])['type'],
+        'type' => details[:type] || type(details[:vrn]),
         'charges' => {
           'leeds' => details[:leeds_charge] || 12.5,
           'birmingham' => details[:birmingham_charge] || 8
         }
       }
+    end
+
+    def type(vrn)
+      type = ComplianceCheckerApi.vehicle_details(vrn)['type']
+      type == 'null' ? 'unrecognised' : type
     end
     #:nocov:
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,21 +14,24 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Enable redis cache store for session
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] } if ENV['REDIS_URL']
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  # if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  #   config.action_controller.perform_caching = true
+  #   config.action_controller.enable_fragment_cache_logging = true
+  #
+  #   config.cache_store = :memory_store
+  #   config.public_file_server.headers = {
+  #     'Cache-Control' => "public, max-age=#{2.days.to_i}"
+  #   }
+  # else
+  #   config.action_controller.perform_caching = false
+  #
+  #   config.cache_store = :null_store
+  # end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   # config.active_storage.service = :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
   config.log_tags = %i[request_id remote_ip]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] } if ENV['REDIS_URL']
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 timeout_in_mins = Rails.configuration.x.session_timeout_in_min.minutes
-Rails.application.config.session_store :cookie_store,
+store_type = ENV['REDIS_URL'] ? :cache_store : :cookie_store
+Rails.application.config.session_store store_type,
                                        key: '_caz-fleets_session',
                                        expire_after: timeout_in_mins,
-                                       same_site: :strict
+                                       same_site: :lax
 # secure: Rails.env.production?


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-1834

## Description
<!--- Describe your changes in detail -->
Added Redis store which is configured via `REDIS_URL` env variable. If the variable is empty, server falls back to the cookie-based store.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
