### PR TITLE
[CAZ-2027] Add reset url to initiate_password_reset

### DIFF
--- a/app/api_wrappers/accounts_api.rb
+++ b/app/api_wrappers/accounts_api.rb
@@ -134,9 +134,9 @@ class AccountsApi < BaseApi
     # * {400 Exception}[rdoc-ref:BaseApi::Error400Exception] - invalid email address
     # * {500 Exception}[rdoc-ref:BaseApi::Error500Exception] - backend API error
     #
-    def initiate_password_reset(email:)
+    def initiate_password_reset(email:, reset_url:)
       log_action('Initiating password reset')
-      body = { email: email }.to_json
+      body = { email: email, resetUrl: reset_url }.to_json
       request(:post, '/auth/password/reset', body: body)
       true
     end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -31,7 +31,7 @@ class PasswordsController < ApplicationController
   def validate
     form = ResetPasswordForm.new(email_address_params)
     if form.valid?
-      AccountsApi.initiate_password_reset(email: form.email_address)
+      AccountsApi.initiate_password_reset(email: form.email_address, reset_url: passwords_url)
       redirect_to email_sent_passwords_path
     else
       @errors = form.errors.messages

--- a/features/step_definitions/password_reset_steps.rb
+++ b/features/step_definitions/password_reset_steps.rb
@@ -6,7 +6,10 @@ end
 
 When('I enter valid email address') do
   email = 'example@email.com'
-  allow(AccountsApi).to receive(:initiate_password_reset).with(email: email).and_return(true)
+  allow(AccountsApi)
+    .to receive(:initiate_password_reset)
+    .with(email: email, reset_url: passwords_url)
+    .and_return(true)
   fill_in('passwords[email_address]', with: email)
   click_button 'Send email'
 end

--- a/spec/api_wrappers/accounts_api/initiate_password_reset_spec.rb
+++ b/spec/api_wrappers/accounts_api/initiate_password_reset_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 describe 'AccountsApi.initiate_password_reset' do
-  subject(:call) { AccountsApi.initiate_password_reset(email: email) }
+  subject(:call) { AccountsApi.initiate_password_reset(email: email, reset_url: reset_url) }
 
   let(:email) { 'test@example.com' }
   let(:url) { %r{auth/password/reset} }
+  let(:reset_url) { 'http://wp.pl' }
 
   before do
     stub_request(:post, url).to_return(
@@ -19,7 +20,7 @@ describe 'AccountsApi.initiate_password_reset' do
     call
     expect(WebMock)
       .to have_requested(:post, url)
-      .with(body: { email: email })
+      .with(body: { email: email, resetUrl: reset_url })
       .once
   end
 

--- a/spec/requests/passwords/validate_spec.rb
+++ b/spec/requests/passwords/validate_spec.rb
@@ -19,7 +19,9 @@ describe 'PasswordsController - POST #validate' do
     end
 
     it 'calls AccountsApi.initiate_password_reset' do
-      expect(AccountsApi).to receive(:initiate_password_reset).with(email: email_address)
+      expect(AccountsApi)
+        .to receive(:initiate_password_reset)
+        .with(email: email_address, reset_url: passwords_url)
       http_request
     end
   end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Relates to this change: https://github.com/InformedSolutions/JAQU-CAZ-Java-Common/pull/106/

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screen Shot 2020-02-26 at 09 22 31](https://user-images.githubusercontent.com/16211686/75325721-9312ee80-5879-11ea-8c00-2e3480e7e0b7.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
