### PR TITLE
[CAZ-2122] User password reset - wrong message for empty email

### DIFF
--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -19,5 +19,5 @@ class ResetPasswordForm < BaseForm
   validates :email_address, format: {
     with: EMAIL_FORMAT,
     message: I18n.t('input_form.errors.invalid_format')
-  }
+  }, allow_blank: true
 end

--- a/features/password_reset.feature
+++ b/features/password_reset.feature
@@ -8,7 +8,7 @@ Feature: Password reset
       And I should see "Reset your password"
     When I enter invalid email address
       And I should see "There is a problem"
-      And I should see "[TBA] Email address is required, [TBA] Email address is in an invalid format"
+      And I should see "[TBA] Email address is required"
     When I enter valid email address
       And I should be on the email sent page
 

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -23,7 +23,7 @@ describe ResetPasswordForm, type: :model do
     it 'has a proper error message' do
       form.valid?
       expect(form.errors.messages[:email_address].join(',')).to include(
-        I18n.t('input_form.errors.invalid_format', attribute: 'Email address')
+        I18n.t('input_form.errors.missing', attribute: 'Email address')
       )
     end
   end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA](https://eaflood.atlassian.net/browse/CAZ-2122)
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![fleets_password_reqiured](https://user-images.githubusercontent.com/24584219/75906185-92b0bf80-5e46-11ea-885f-449d1711ba62.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
