### PR TITLE
[CAZ-2021] Store Initiate payment session

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -108,6 +108,9 @@ class PaymentsController < ApplicationController
       payment_data: helpers.new_payment_data,
       user_id: current_user.user_id
     )
+
+    SessionManipulation::AddCurrentPayment.call(session: session)
+
     redirect_to next_url
   end
 

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -6,6 +6,11 @@ module PaymentsHelper
     (session[:new_payment] || {}).symbolize_keys
   end
 
+  # Gets data about the current payment from the session
+  def initiated_payment_data
+    (session[:initiated_payment] || {}).symbolize_keys
+  end
+
   # Extracts :payment_query form the session
   def payment_query_data
     (session[:payment_query] || {}).symbolize_keys

--- a/app/services/make_payment.rb
+++ b/app/services/make_payment.rb
@@ -73,10 +73,15 @@ class MakePayment < BaseService
     payment_detail[:dates].map do |date|
       {
         vrn: payment_detail[:vrn],
-        charge: payment_detail[:charge],
+        charge: charge_in_pence(payment_detail[:charge]),
         travel_date: date,
         tariff_code: payment_detail[:tariff]
       }
     end
+  end
+
+  # convert charge in pence
+  def charge_in_pence(charge_in_pounds)
+    (charge_in_pounds.to_f * 100).to_i
   end
 end

--- a/app/services/session_manipulation/add_current_payment.rb
+++ b/app/services/session_manipulation/add_current_payment.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SessionManipulation
+  ##
+  # Saves submitted vehicles and initiated payment details.
+  # Session used to store provided data after payment initiation.
+  #
+  class AddCurrentPayment < BaseManipulator
+    ##
+    # Instance level +call+ method
+    #
+    def call
+      session[:initiated_payment] = session[:new_payment]
+      session[:new_payment] = {}
+    end
+  end
+end

--- a/spec/services/make_payment_spec.rb
+++ b/spec/services/make_payment_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe MakePayment do
   subject(:call) { described_class.call(payment_data: payment_data, user_id: user_id) }
+  let(:charge_in_pounds) { 50.0 }
   let(:payment_data) do
     {
       la_id: caz_id,
@@ -11,7 +12,7 @@ describe MakePayment do
         'PAY015' => {
           vrn: 'PAY015',
           tariff: 'BCC01-HEAVY GOODS VEHICLE',
-          charge: 50.0,
+          charge: charge_in_pounds,
           dates: ['2020-03-04']
         }
       }
@@ -29,7 +30,7 @@ describe MakePayment do
       transactions: [
         {
           vrn: 'PAY015',
-          charge: 50.0,
+          charge: charge_in_pounds * 100, # charge in pence
           travel_date: '2020-03-04',
           tariff_code: 'BCC01-HEAVY GOODS VEHICLE'
         }


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira card: https://eaflood.atlassian.net/browse/CAZ-2021
We need to store the session of initiated payment but we don't want to reuse it for the next payments. 

## Description
<!--- Describe your changes in detail -->
Added new key to the session to store initiated payment details.
After the changes, we clear the session for new_payment after payment initiation.
Additionally fixed the bug with sending pounds instead of pence values for charges. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixed unit tests. 
To test sessions:
Process, the first transaction to the payment page. 
And then that try to create a new transaction in a new window. 

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
