### PR TITLE
Wrap clear search link javascript in null check

### DIFF
--- a/app/javascript/src/payment_matrix/initSearch.js
+++ b/app/javascript/src/payment_matrix/initSearch.js
@@ -12,10 +12,12 @@ export default function () {
         submitForm(paymentForm);
     });
 
-    initClearButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      paymentForm.appendChild(createHiddenInput("commit", "Clear search"));
-      document.getElementById("vrn-search").value = "";
-      submitForm(paymentForm);
-    });
+    if (initClearButton != null) {
+      initClearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        paymentForm.appendChild(createHiddenInput("commit", "Clear search"));
+        document.getElementById("vrn-search").value = "";
+        submitForm(paymentForm);
+      });
+    }
 }


### PR DESCRIPTION
Wraps the clear search link in a null check to avoid javascript errors being raised on page load when no search has been triggered.

Note this is to resolve pagination triggers not firing (as the JS doesn't get attached).