### PR TITLE
Remove all whitespace from search input value

### DIFF
--- a/app/javascript/src/payment_matrix/createHiddenInput.js
+++ b/app/javascript/src/payment_matrix/createHiddenInput.js
@@ -2,6 +2,6 @@ export default function(name, value) {
     const input = document.createElement("input");
     input.type = "hidden";
     input.name = name;
-    input.value = value.toUpperCase();
+    input.value = value.replace(/\s/g, "").toUpperCase();
     return input;
 };


### PR DESCRIPTION
This previously would raise error on a search being triggered. The regex approach supports vrns with whitespace inside (rather than a simply trim on the string).