### PR TITLE
[CAZ-2294] Login Page errors refinement

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,4 +59,3 @@ en:
   token_form:
     token_missing: 'Authorisation token is missing'
     token_invalid: 'Authorisation token is invalid or has expired'
-

--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -32,8 +32,8 @@ Feature: Sign In
     When I enter invalid credentials
     Then I remain on the current page
       And I should see "The email or password you entered is incorrect"
-      And I should see "Enter your email address"
-      And I should see "Enter your password"
+      And I should not see "Enter your email address"
+      And I should not see "Enter your password"
 
   Scenario: Sign in with unconfirmed email
     Given I am on the Sign in page

--- a/lib/devise/strategies/remote.rb
+++ b/lib/devise/strategies/remote.rb
@@ -60,8 +60,8 @@ module Devise
       def add_unauthorized_errors
         # Sets errors with base error to display in the error summary
         errors.add(:base, I18n.t('login_form.incorrect'))
-        errors.add(:email, I18n.t('login_form.email_missing'))
-        errors.add(:password, I18n.t('login_form.password_missing'))
+        errors.add(:email, nil)
+        errors.add(:password, nil)
         fail!(:invalid)
       end
 

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -58,12 +58,12 @@ describe 'User signing in', type: :request do
 
     it 'shows email error message once' do
       http_request
-      expect(body_scan(I18n.t('login_form.email_missing'))).to eq(1)
+      expect(body_scan(I18n.t('login_form.email_missing'))).to eq(0)
     end
 
     it 'shows password error message once' do
       http_request
-      expect(body_scan(I18n.t('login_form.password_missing'))).to eq(1)
+      expect(body_scan(I18n.t('login_form.password_missing'))).to eq(0)
     end
   end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[CAZ-2294](https://eaflood.atlassian.net/browse/CAZ-2294)

## Description
<!--- Describe your changes in detail -->
* Removes `Enter your email address` and `Enter your password` information when provided both email and password but one of them is invalid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually
* Adjusted RSpec and cucumber specs.

## Screenshots (if appropriate):
![Screenshot 2020-04-01 at 17 09 52](https://user-images.githubusercontent.com/4506633/78156134-a26bf580-743e-11ea-9d03-ecd5fa8d4d60.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
