### PR TITLE
[CAZ-2297] Remove back link from Reset Password token expired page

### DIFF
--- a/app/views/passwords/invalid.html.haml
+++ b/app/views/passwords/invalid.html.haml
@@ -1,5 +1,3 @@
-= link_to 'Back', reset_passwords_url, class: 'govuk-back-link'
-
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/features/password_reset.feature
+++ b/features/password_reset.feature
@@ -16,6 +16,7 @@ Feature: Password reset
   Scenario: Visit passwords without the token
     Given I visit passwords without the token
     Then I should be on the invalid page
+      And I should not see "Back" link
 
   Scenario: Changing password
     Given I visit passwords


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2297
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![reset_page](https://user-images.githubusercontent.com/24584219/78669524-b0a59000-78dc-11ea-8da0-e19c06ebd8f1.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
