### PR TITLE
[CAZ-2294] Remove red lines for email/password fields

### DIFF
--- a/lib/devise/strategies/remote.rb
+++ b/lib/devise/strategies/remote.rb
@@ -60,8 +60,6 @@ module Devise
       def add_unauthorized_errors
         # Sets errors with base error to display in the error summary
         errors.add(:base, I18n.t('login_form.incorrect'))
-        errors.add(:email, nil)
-        errors.add(:password, nil)
         fail!(:invalid)
       end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2294
## Description
<!--- Describe your changes in detail -->
```Just as a quick note on the above - as we’re not showing an error message - the CSS for the email/password fields does not need to be rendered in red.```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![sign_erros](https://user-images.githubusercontent.com/24584219/79212510-0a133f00-7e48-11ea-9894-de31fafd986a.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
