### PR TITLE
[CAZ-2348] Updated checkboxes values to be more user friendly

### DIFF
--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -67,4 +67,9 @@ module PaymentsHelper
   def external_urls
     YAML.load_file('additional_urls.yaml')
   end
+
+  # Transforms a date into more user friendly string such as '25 March 2020'.
+  def formatted_date_string(date)
+    Date.parse(date).strftime('%d %B %Y')
+  end
 end

--- a/app/services/base_payment.rb
+++ b/app/services/base_payment.rb
@@ -36,7 +36,7 @@ class BasePayment < BaseService
       {
         vrn: payment_detail[:vrn],
         charge: charge_in_pence(payment_detail[:charge]),
-        travel_date: date,
+        travel_date: Date.parse(date).to_s,
         tariff_code: payment_detail[:tariff]
       }
     end

--- a/app/views/payments/matrix.html.haml
+++ b/app/views/payments/matrix.html.haml
@@ -19,7 +19,7 @@
             = hidden_field_tag('allSelectedCheckboxesCount', selected_dates_count)
             .govuk-tabs{'data-module': 'govuk-tabs'}
               - if @search && !@charges.any_results?
-                = render 'payments/matrix/no_chnargeable_vehicles'
+                = render 'payments/matrix/no_chargeable_vehicles'
               - else
                 = render 'payments/matrix/tabs'
                 = render 'payments/matrix/past_week_tab', form: f

--- a/app/views/payments/matrix/_no_chargeable_vehicles.html.haml
+++ b/app/views/payments/matrix/_no_chargeable_vehicles.html.haml
@@ -4,9 +4,9 @@
 %p
   It might be because:
   %ul.govuk-list-govuk-list--bullet
-    %li 
+    %li
       %p You did not upload that vehicle to your list
     %li
-      %p 
+      %p
         It is not subject to a charge in
         = @zone.name

--- a/app/views/payments/matrix/_table.html.haml
+++ b/app/views/payments/matrix/_table.html.haml
@@ -19,10 +19,10 @@
             - else
               .govuk-checkboxes__item
                 %input.govuk-checkboxes__input{name: "payment[vehicles][#{vehicle.vrn}][]",
-                                               value: date[:value],
+                                               value: formatted_date_string(date[:value]),
                                                id: id,
                                                type: 'checkbox',
-                                               checked: checked?(vehicle.vrn, date[:value])}
+                                               checked: checked?(vehicle.vrn, formatted_date_string(date[:value]))}
                 %label.govuk-label.govuk-checkboxes__label{for: id}
                   %span.govuk-visually-hidden
                     = date[:value]


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2348

## Description
<!--- Describe your changes in detail -->
* As some of the screen readers have problems with reading dates in the previously existing format (e.g. "2020-03-25"), the introduced change makes the format more user friendly (e.g. "25 March 2020"). When the request is being sent to the backend, the dates are transformed to the format which was used earlier so that does not violate the integration. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually tested if the payment process works the same as it was.

## Screenshots (if appropriate):
N/A
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
