### PR TITLE
[CAZ-2513] DirectDebit mandate text change

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DashboardController < ApplicationController
+  before_action :assign_debit, only: :index
+
   ##
   # Renders the dashboard page.
   #
@@ -11,6 +13,7 @@ class DashboardController < ApplicationController
   def index
     clear_input_history
     @vehicles_present = !current_user.fleet.empty?
+    @mandates_present = @debit.active_mandates.any?
   end
 
   private
@@ -22,5 +25,10 @@ class DashboardController < ApplicationController
     session[:payment_method] = nil
     session[:submission_method] = nil
     session[:new_payment] = nil
+  end
+
+  # Creates an instance of DirectDebit class and assign it to +@debit+ variable
+  def assign_debit
+    @debit = DirectDebit.new(current_user.account_id)
   end
 end

--- a/app/views/dashboard/_direct_debit.html.haml
+++ b/app/views/dashboard/_direct_debit.html.haml
@@ -1,5 +1,11 @@
 %article.dashboard-total-group.govuk-grid-column-one-third
-  %p.govuk-body{class: 'govuk-!-font-size-16 govuk-!-margin-top-9'}
-    %strong
-      = link_to('Create a Direct Debit mandate', debits_path, id: 'direct-debit')
-  %p.govuk-body Create a Direct Debit mandate to allow BACS payments
+  - if @mandates_present
+    %p.govuk-body{class: 'govuk-!-font-size-16 govuk-!-margin-top-9'}
+      %strong
+        = link_to('Your direct debits', debits_path, id: 'direct-debit')
+    %p.govuk-body View the Direct Debits you’ve created with each zone
+  - else
+    %p.govuk-body{class: 'govuk-!-font-size-16 govuk-!-margin-top-9'}
+      %strong
+        = link_to('Create a Direct Debit mandate', debits_path, id: 'direct-debit')
+    %p.govuk-body Create a Direct Debit mandate to allow BACS payments

--- a/features/debits.feature
+++ b/features/debits.feature
@@ -49,7 +49,7 @@ Feature: Debits
       And I should see 'Set up new direct debit' link
       And I should not see 'You have created a mandate for each CAZ'
     Then I press `Set up new direct debit` button
-       And I should see 'Which Clean Air Zone do you need to set up a direct debit with?'
+      And I should see 'Which Clean Air Zone do you need to set up a direct debit with?'
 
   Scenario: Visiting the manage direct debit page with all mandates
     When I have created all the possible mandates

--- a/features/fleets.feature
+++ b/features/fleets.feature
@@ -33,7 +33,7 @@ Feature: Fleets
     Then I should be on the manage vehicles page
     Then I press the Continue
     Then I should see "You must choose an answer"
-    
+
   Scenario: Removing vehicle from the fleet
     When I have vehicles in my fleet
       And I visit the manage vehicles page
@@ -45,7 +45,7 @@ Feature: Fleets
       And I press the Continue
     Then I should be on the manage vehicles page
       And I should have deleted the vehicle
-    
+
   Scenario: Backend API is unavailable
     When Fleet backend API is unavailable
       And I visit the manage vehicles page

--- a/features/step_definitions/debits_steps.rb
+++ b/features/step_definitions/debits_steps.rb
@@ -2,7 +2,7 @@
 
 When('I have no mandates') do
   mock_vehicles_in_fleet
-  mock_debits('inactive_mandates')
+  mock_debits_api_call('inactive_mandates')
 end
 
 When('I visit the manage direct debit page') do
@@ -20,12 +20,12 @@ end
 
 When('I have created mandates') do
   mock_vehicles_in_fleet
-  mock_debits
+  mock_debits_api_call
 end
 
 When('I have created all the possible mandates') do
   mock_vehicles_in_fleet
-  mock_debits('active_mandates')
+  mock_debits_api_call('active_mandates')
 end
 
 Then('I should be on the manage debits page') do
@@ -38,12 +38,12 @@ When('I visit the add new mandate page') do
 end
 
 Then('I press `Set up new direct debit` button') do
-  mock_debits('inactive_mandates')
+  mock_debits_api_call('inactive_mandates')
   click_button 'Set up new direct debit'
 end
 
 Then('I should have a new mandate added') do
-  mock_debits
+  mock_debits_api_call
   allow(DebitsApi).to receive(:create_mandate).and_return(true)
 end
 
@@ -53,35 +53,4 @@ end
 
 When('I have only inactive mandates for selected CAZ') do
   mock_api_endpoints('inactive_caz_mandates')
-end
-
-private
-
-def mock_api_endpoints(caz_mandates = 'caz_mandates')
-  mock_clean_air_zones
-  mock_vehicles_in_fleet
-  mock_debits('mandates')
-  mock_caz_mandates(caz_mandates)
-  mock_create_mandate
-  mock_create_payment
-end
-
-def mock_debits(mocked_file = 'mandates')
-  api_response = read_response("/debits/#{mocked_file}.json")['cleanAirZones']
-  allow(DebitsApi).to receive(:mandates).and_return(api_response)
-end
-
-def mock_caz_mandates(mocked_file = 'caz_mandates')
-  api_response = read_response("/debits/#{mocked_file}.json")['mandates']
-  allow(DebitsApi).to receive(:caz_mandates).and_return(api_response)
-end
-
-def mock_create_payment
-  api_response = read_response('/debits/create_payment.json')
-  allow(DebitsApi).to receive(:create_payment).and_return(api_response)
-end
-
-def mock_create_mandate
-  api_response = read_response('/debits/create_mandate.json')
-  allow(DebitsApi).to receive(:create_mandate).and_return(api_response)
 end

--- a/features/step_definitions/fleets_steps.rb
+++ b/features/step_definitions/fleets_steps.rb
@@ -2,6 +2,7 @@
 
 When('I have no vehicles in my fleet') do
   mock_empty_fleet
+  mock_debits
 end
 
 When('I visit the manage vehicles page') do
@@ -11,6 +12,7 @@ end
 
 When('I visit the submission method page') do
   mock_vehicles_in_fleet
+  mock_debits
   login_user
   visit submission_method_fleets_path
 end
@@ -32,6 +34,7 @@ Then('I should be on the upload page') do
 end
 
 When('I have vehicles in my fleet') do
+  mock_debits
   mock_clean_air_zones
   mock_vehicles_in_fleet
 end

--- a/features/step_definitions/navigate_pages_steps.rb
+++ b/features/step_definitions/navigate_pages_steps.rb
@@ -2,10 +2,12 @@
 
 When('I navigate to a Dashboard page') do
   mock_vehicles_in_fleet
+  mock_debits('active_mandates')
   visit dashboard_path
 end
 
 When('I navigate to a Dashboard page with empty fleets') do
   mock_empty_fleet
+  mock_debits('inactive_mandates')
   visit dashboard_path
 end

--- a/features/step_definitions/payments_steps.rb
+++ b/features/step_definitions/payments_steps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 When('I visit the make payment page') do
+  mock_debits
   login_user
   visit payments_path
 end
@@ -38,6 +39,7 @@ Then('I should be on the Charge details page') do
 end
 
 And('I want to confirm my payment') do
+  mock_debits
   mock_requests_to_payments_api_with(return_url: result_payments_path)
 end
 

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -20,6 +20,7 @@ end
 
 When('I have authentication cookie that has not expired') do
   mock_vehicles_in_fleet
+  mock_debits
   visit new_user_session_path
   login_user
 
@@ -64,6 +65,7 @@ Given('I have authentication cookie that has expired') do
 
   travel_to(20.minutes.ago) do
     mock_vehicles_in_fleet
+    mock_debits
     login_user
   end
 
@@ -74,6 +76,7 @@ end
 
 Given('I am signed in') do
   mock_vehicles_in_fleet
+  mock_debits
   login_user
 end
 

--- a/features/step_definitions/uploads_step.rb
+++ b/features/step_definitions/uploads_step.rb
@@ -28,6 +28,7 @@ end
 
 When('I am on the processing page') do
   mock_vehicles_in_fleet
+  mock_debits
   login_user
   page.set_rack_session(
     job: { job_name: SecureRandom.uuid, correlation_id: SecureRandom.uuid }

--- a/features/step_definitions/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_steps.rb
@@ -2,6 +2,7 @@
 
 When('I visit the enter details page') do
   mock_vehicles_in_fleet
+  mock_debits
   login_user
   visit enter_details_vehicles_path
 end

--- a/features/support/mock_debit.rb
+++ b/features/support/mock_debit.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module MockDebit
+  def mock_api_endpoints(caz_mandates = 'caz_mandates')
+    mock_clean_air_zones
+    mock_vehicles_in_fleet
+    mock_debits('mandates')
+    mock_caz_mandates(caz_mandates)
+    mock_create_mandate
+    mock_create_payment
+  end
+
+  def mock_debits_api_call(mocked_file = 'mandates')
+    api_response = read_response("/debits/#{mocked_file}.json")
+    stub_request(:get, /direct-debit-mandate/).to_return(
+      status: 200,
+      body: api_response.to_json
+    )
+  end
+
+  def mock_debits(mocked_file = 'mandates')
+    api_response = read_response("/debits/#{mocked_file}.json")['cleanAirZones']
+    allow(DebitsApi).to receive(:mandates).and_return(api_response)
+  end
+
+  def mock_caz_mandates(mocked_file = 'caz_mandates')
+    api_response = read_response("/debits/#{mocked_file}.json")['mandates']
+    allow(DebitsApi).to receive(:caz_mandates).and_return(api_response)
+  end
+
+  def mock_create_payment
+    api_response = read_response('/debits/create_payment.json')
+    allow(DebitsApi).to receive(:create_payment).and_return(api_response)
+  end
+
+  def mock_create_mandate
+    api_response = read_response('/debits/create_mandate.json')
+    allow(DebitsApi).to receive(:create_mandate).and_return(api_response)
+  end
+end
+
+World(MockDebit)

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -49,4 +49,3 @@ Feature: Vehicles
       And I press the Confirm
     Then I should be on the details page
       And I should see "You must choose an answer" 2 times
-

--- a/spec/fixtures/responses/debits/active_mandates.json
+++ b/spec/fixtures/responses/debits/active_mandates.json
@@ -1,32 +1,32 @@
 {
   "cleanAirZones": [
     {
-       "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
-       "cazName": "Leeds",
-       "mandates": [
-         {
-           "id": "5cd7441d-766f-48ff-b8ad-1809586fea37",
-           "status": "pending"
-         }
-       ]
+      "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
+      "cazName": "Leeds",
+      "mandates": [
+        {
+          "id": "5cd7441d-766f-48ff-b8ad-1809586fea37",
+          "status": "pending"
+        }
+      ]
     },
     {
-       "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
-       "cazName": "Birmingham",
-       "mandates": [
-         {
-           "id": "55f9d425-f60b-4919-9020-b6e48d641ba4",
-           "status": "active"
-         },
-         {
-           "id": "09b72307-e56a-4b61-802a-03eee58748ba",
-           "status": "failed"
-         },
-         {
-           "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
-           "status": "cancelled"
-         }
-       ]
+      "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
+      "cazName": "Birmingham",
+      "mandates": [
+        {
+          "id": "55f9d425-f60b-4919-9020-b6e48d641ba4",
+          "status": "active"
+        },
+        {
+          "id": "09b72307-e56a-4b61-802a-03eee58748ba",
+          "status": "failed"
+        },
+        {
+          "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
+          "status": "cancelled"
+        }
+      ]
     }
   ]
 }

--- a/spec/fixtures/responses/debits/inactive_mandates.json
+++ b/spec/fixtures/responses/debits/inactive_mandates.json
@@ -1,28 +1,28 @@
 {
   "cleanAirZones": [
     {
-       "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
-       "cazName": "Leeds",
-       "mandates": [
-         {
-           "id": "5cd7441d-766f-48ff-b8ad-1809586fea37",
-           "status": "cancelled"
-         }
-       ]
+      "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
+      "cazName": "Leeds",
+      "mandates": [
+        {
+          "id": "5cd7441d-766f-48ff-b8ad-1809586fea37",
+          "status": "cancelled"
+        }
+      ]
     },
     {
-       "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
-       "cazName": "Birmingham",
-       "mandates": [
-         {
-           "id": "09b72307-e56a-4b61-802a-03eee58748ba",
-           "status": "failed"
-         },
-         {
-           "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
-           "status": "cancelled"
-         }
-       ]
+      "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
+      "cazName": "Birmingham",
+      "mandates": [
+        {
+          "id": "09b72307-e56a-4b61-802a-03eee58748ba",
+          "status": "failed"
+        },
+        {
+          "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
+          "status": "cancelled"
+        }
+      ]
     }
   ]
 }

--- a/spec/fixtures/responses/debits/mandates.json
+++ b/spec/fixtures/responses/debits/mandates.json
@@ -1,27 +1,27 @@
 {
   "cleanAirZones": [
     {
-       "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
-       "cazName": "Leeds",
-       "mandates": []
+      "cazId": "87c17807-d6ec-4128-9174-9ce66cc5ed73",
+      "cazName": "Leeds",
+      "mandates": []
     },
     {
-       "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
-       "cazName": "Birmingham",
-       "mandates": [
-         {
-           "id": "55f9d425-f60b-4919-9020-b6e48d641ba4",
-           "status": "active"
-         },
-         {
-           "id": "09b72307-e56a-4b61-802a-03eee58748ba",
-           "status": "failed"
-         },
-         {
-           "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
-           "status": "cancelled"
-         }
-       ]
+      "cazId": "90fa62ca-c9dc-48b3-81c2-66b6f0d28b38",
+      "cazName": "Birmingham",
+      "mandates": [
+        {
+          "id": "55f9d425-f60b-4919-9020-b6e48d641ba4",
+          "status": "active"
+        },
+        {
+          "id": "09b72307-e56a-4b61-802a-03eee58748ba",
+          "status": "failed"
+        },
+        {
+          "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
+          "status": "cancelled"
+        }
+      ]
     }
   ]
 }

--- a/spec/requests/dashboard_controller_spec.rb
+++ b/spec/requests/dashboard_controller_spec.rb
@@ -14,6 +14,7 @@ describe DashboardController, type: :request do
     context 'when user is signed in' do
       before do
         mock_fleet
+        mock_debits
         sign_in create_user
       end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2513 - fix card for:
https://eaflood.atlassian.net/browse/CAZ-2511

## Description
<!--- Describe your changes in detail -->
* `DirectDebitMandates` are now fetched when entering the dashboard page. When a user has any active direct debits the new copy is displayed for him.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**When a user has no mandates:**
![Screenshot 2020-04-23 at 11 47 35](https://user-images.githubusercontent.com/4506633/80209937-2dea3800-8633-11ea-88eb-5cbc9c8e0c20.png)

----
**When a user has active mandates:**
![Screenshot 2020-04-23 at 11 47 16](https://user-images.githubusercontent.com/4506633/80209944-33478280-8633-11ea-9e3e-d72e16352f9f.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
