### PR TITLE
[CAZ-2339] Allow manual addition of unknown vehicles to fleet

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -122,6 +122,21 @@ class VehiclesController < ApplicationController
     @vehicle_registration = vrn
   end
 
+  ##
+  # Validates user has confirmed VRN not found is correct.
+  # If it is valid, redirects to  {manage vehicles page}[rdoc-ref:FleetsController.index]
+  # If not, renders {not found}[rdoc-ref:VehiclesController.not_found] with errors
+  #
+  # ==== Path
+  #    POST /vehicles/not_found
+  #
+  def confirm_not_found
+    form = ConfirmationForm.new(params['confirm-registration'])
+    return redirect_to not_found_vehicles_path, alert: confirmation_error(form) unless form.valid?
+
+    add_vehicle_to_fleet
+  end
+
   private
 
   # Check if vrn is present in the session

--- a/app/views/vehicles/not_found.html.haml
+++ b/app/views/vehicles/not_found.html.haml
@@ -5,7 +5,7 @@
       - if alert
         = render 'common/error_summary',
           error_msg_div: '#unrecognised-vehicle-error',
-          error_msg: I18n.t('confirmation_alert')
+          error_msg: I18n.t('vehicle_not_found.errors.confirmation_alert')
 
       %h1.govuk-heading-xl Vehicle details could not be found
       %p
@@ -39,12 +39,12 @@
         .govuk-form-group{class: ('govuk-form-group--error' if alert)}
           %fieldset.govuk-fieldset
             %legend.govuk-visually-hidden
-              = I18n.t('confirmation_alert')
+              = I18n.t('vehicle_not_found.errors.confirmation_alert')
 
             - if alert
               %span#unrecognised-vehicle-error.govuk-error-message
                 %span.govuk-visually-hidden Error:
-                = I18n.t('confirmation_alert')
+                = I18n.t('vehicle_not_found.errors.confirmation_alert')
 
             .govuk-checkboxes
               .govuk-checkboxes__item

--- a/app/views/vehicles/not_found.html.haml
+++ b/app/views/vehicles/not_found.html.haml
@@ -1,21 +1,57 @@
-- title_and_header = 'Vehicle details could not be found'
-- content_for(:title, title_and_header)
-
-= link_to 'Back', enter_details_vehicles_path, class: 'govuk-back-link'
-
+= link_to 'Back', enter_details_vehicles_path, class: 'govuk-back-link', id: 'back-link'
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %h1.govuk-heading-l.not-found-title
-        = title_and_header
-      %table.govuk-table
-        %tbody.govuk-table__body
-          %tr.govuk-table__row
-            %td.govuk-table__cell{scope: 'row'}
-            %td.govuk-table__cell
-          %tr.govuk-table__row
-            %td.govuk-table__cell{scope: 'row'} You searched for
-            %th.govuk-table__cell= @vehicle_registration
+      - if alert
+        = render 'common/error_summary',
+          error_msg_div: '#unrecognised-vehicle-error',
+          error_msg: I18n.t('confirmation_alert')
+
+      %h1.govuk-heading-xl Vehicle details could not be found
       %p
-        If you are sure that you entered the correct number plate and you need to make a further enquiries please contact
-        = external_link_to 'DVLA', 'https://www.gov.uk/change-vehicle-details-registration-certificate'
+        Try
+        = link_to 'entering your details', enter_details_vehicles_path, class: 'govuk-link'
+        again making sure you have not mixed up letters and numbers (for example, the letters
+        %b I
+        and
+        %b O
+        with the numbers
+        %b 1
+        and
+        %b 0
+        ).
+
+      %h1.govuk-heading-m Check your registration details
+      %p
+        If the details still can not be found and you believe your vehicle should be registered in
+        the UK, you can
+        = external_link_to 'update the details',
+                           'https://www.gov.uk/change-vehicle-details-registration-certificate/how-to-tell-dvla'
+        the DVLA holds for your vehicle.
+
+      %p
+        Confirm the number plate
+        %b
+          = @vrn
+        is correct and add it to your account.
+
+      = form_tag confirm_not_found_vehicles_path, method: :post do
+        .govuk-form-group{class: ('govuk-form-group--error' if alert)}
+          %fieldset.govuk-fieldset
+            %legend.govuk-visually-hidden
+              = I18n.t('confirmation_alert')
+
+            - if alert
+              %span#unrecognised-vehicle-error.govuk-error-message
+                %span.govuk-visually-hidden Error:
+                = I18n.t('confirmation_alert')
+
+            .govuk-checkboxes
+              .govuk-checkboxes__item
+                %input.govuk-checkboxes__input{name: 'confirm-registration',
+                                               type: 'checkbox',
+                                               value: 'yes',
+                                               id: 'confirm-registration'}
+                %label.govuk-label.govuk-checkboxes__label{for: 'confirm-registration'}
+                  I confirm the number plate is correct and I want to add it to my account.
+        = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,4 +65,6 @@ en:
   token_form:
     token_missing: 'Authorisation token is missing'
     token_invalid: 'Authorisation token is invalid or has expired'
-  confirmation_alert: Confirm the number plate is correct
+  vehicle_not_found:
+    errors:
+      confirmation_alert: Confirm the number plate is correct

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,3 +65,4 @@ en:
   token_form:
     token_missing: 'Authorisation token is missing'
     token_invalid: 'Authorisation token is invalid or has expired'
+  confirmation_alert: Confirm the number plate is correct

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       get :exempt
       get :incorrect_details
       get :not_found
+      post :confirm_not_found
     end
   end
 

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -67,3 +67,7 @@ end
 Then('I should see {string} as {string} value') do |string, field|
   expect(page).to have_field(field, with: string)
 end
+
+And('I check {string}') do |string|
+  check(string)
+end

--- a/features/step_definitions/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_steps.rb
@@ -48,6 +48,10 @@ Then('I should be on the vehicle not found page') do
   expect(page).to have_current_path(not_found_vehicles_path)
 end
 
+And('I choose I confirm registration') do
+  check('I confirm the number plate is correct and I want to add it to my account.')
+end
+
 Then('I should be on the incorrect details page') do
   expect(page).to have_current_path(incorrect_details_vehicles_path)
 end

--- a/features/step_definitions/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_steps.rb
@@ -48,10 +48,6 @@ Then('I should be on the vehicle not found page') do
   expect(page).to have_current_path(not_found_vehicles_path)
 end
 
-And('I choose I confirm registration') do
-  check('I confirm the number plate is correct and I want to add it to my account.')
-end
-
 Then('I should be on the incorrect details page') do
   expect(page).to have_current_path(incorrect_details_vehicles_path)
 end

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -38,7 +38,7 @@ Feature: Vehicles
     Then I should see "Confirm the number plate is correct"
       And I should see "There is a problem"
       And I should be on the vehicle not found page
-    Then I choose I confirm registration
+      And I check "I confirm the number plate is correct and I want to add it to my account."
     When I press the Continue to add vehicle
     Then I should be on the manage vehicles page
 

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -33,6 +33,14 @@ Feature: Vehicles
       And I enter not found vrn
       And I press the Continue
     Then I should be on the vehicle not found page
+    Then I should see "Vehicle details could not be found"
+      And I press the Continue
+    Then I should see "Confirm the number plate is correct"
+      And I should see "There is a problem"
+      And I should be on the vehicle not found page
+    Then I choose I confirm registration
+    When I press the Continue to add vehicle
+    Then I should be on the manage vehicles page
 
   Scenario: Adding a vehicle with incorrect details
     When I visit the enter details page

--- a/spec/requests/vehicles/confirm_not_found_spec.rb
+++ b/spec/requests/vehicles/confirm_not_found_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'VehiclesController - POST #confirm_not_found', type: :request do
+  subject(:http_request) do
+    post confirm_not_found_vehicles_path,
+         params: { 'confirm-registration': confirmation }
+  end
+
+  let(:confirmation) { 'yes' }
+  let(:account_id) { SecureRandom.uuid }
+
+  it 'returns redirect to the login page' do
+    http_request
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  context 'when user is signed in' do
+    before { sign_in create_user(account_id: account_id) }
+    before do
+      allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_return(true)
+      add_to_session(vrn: @vrn)
+    end
+
+    context 'when registration confirmed' do
+      it 'returns a found response' do
+        http_request
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to manage vehicles page' do
+        http_request
+        expect(response).to redirect_to(fleets_path)
+      end
+    end
+
+    context 'when registration not confirmed' do
+      let(:confirmation) { nil }
+
+      it 'returns a found response' do
+        http_request
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to not_found page' do
+        http_request
+        expect(response).to redirect_to(not_found_vehicles_path)
+      end
+    end
+  end
+end

--- a/spec/requests/vehicles/confirm_not_found_spec.rb
+++ b/spec/requests/vehicles/confirm_not_found_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe 'VehiclesController - POST #confirm_not_found', type: :request do
   end
 
   context 'when user is signed in' do
-    before { sign_in create_user(account_id: account_id) }
     before do
+      sign_in create_user(account_id: account_id)
       allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_return(true)
       add_to_session(vrn: @vrn)
+      http_request
     end
 
     context 'when registration confirmed' do

--- a/spec/requests/vehicles/confirm_not_found_spec.rb
+++ b/spec/requests/vehicles/confirm_not_found_spec.rb
@@ -26,12 +26,10 @@ RSpec.describe 'VehiclesController - POST #confirm_not_found', type: :request do
 
     context 'when registration confirmed' do
       it 'returns a found response' do
-        http_request
         expect(response).to have_http_status(:found)
       end
 
       it 'redirects to manage vehicles page' do
-        http_request
         expect(response).to redirect_to(fleets_path)
       end
     end
@@ -40,12 +38,10 @@ RSpec.describe 'VehiclesController - POST #confirm_not_found', type: :request do
       let(:confirmation) { nil }
 
       it 'returns a found response' do
-        http_request
         expect(response).to have_http_status(:found)
       end
 
       it 'redirects to not_found page' do
-        http_request
         expect(response).to redirect_to(not_found_vehicles_path)
       end
     end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously you were able to upload unknown vehicles via CSV but not able to manually add them. On checking the business requirement, it was specificied that users should be able to add unknown vehicles via the UI.
Fixes [CAZ-2339](https://eaflood.atlassian.net/browse/CAZ-2339)

## Description
<!--- Describe your changes in detail -->
- Change unknown vehicle page to mirror IOD (including new confirmation checkbox).
- Add unknown vehicle to account when 'Continue' pressed on this page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- New `rspec` tests
- New `cucumber` tests
- Manually

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
