### PR TITLE
Fix `Back` link on the `Review your payment` page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
   ##
   # Health endpoint
   #
-  # Used as a healthcheck - returns 200 HTTP status
+  # Used as a health check - returns 200 HTTP status
   #
   # ==== Path
   #
@@ -104,7 +104,7 @@ class ApplicationController < ActionController::Base
 
   # Checks if the user selected LA
   def check_la
-    @zone_id = helpers.new_payment_data[:la_id]
+    @zone_id = helpers.new_payment_data[:la_id] || helpers.initiated_payment_data[:la_id]
     redirect_to payments_path unless @zone_id
   end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->
The reason why it's happens:
```
  class AddCurrentPayment < BaseManipulator
    ##
    # Instance level +call+ method
    #
    def call
      session[:initiated_payment] = session[:new_payment]
      session[:new_payment] = {}
    end
  end
```
We are clearing `new_payment` session when initiating a payment
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
