### PR TITLE
Fix issue with second initiating the payment

### DIFF
--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -10,7 +10,7 @@ class CreditCardsController < ApplicationController
   #     GET /payments/initiate
   #
   def initiate
-    service_response = MakeCardPayment.call(payment_data: helpers.new_payment_data,
+    service_response = MakeCardPayment.call(payment_data: payment_data,
                                             user_id: current_user.user_id,
                                             return_url: result_payments_url)
     store_payment_data_in_session(service_response)
@@ -52,5 +52,10 @@ class CreditCardsController < ApplicationController
     store_params = { payment_id: response['paymentId'] }
     SessionManipulation::SetPaymentId.call(session: session, params: store_params)
     SessionManipulation::AddCurrentPayment.call(session: session)
+  end
+
+  # Checks if +new_payment_data+ present if not returns +initiated_payment_data+
+  def payment_data
+    helpers.new_payment_data.present? ? helpers.new_payment_data : helpers.initiated_payment_data
   end
 end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->
Error in `app/services/base_payment.rb`, we're clearing session because of https://eaflood.atlassian.net/browse/CAZ-2021
```
NoMethodError - private method `select' called for nil:NilClass:
  app/services/base_payment.rb:27:in `transformed_transactions'
  app/services/make_card_payment.rb:32:in `call'
  app/services/base_service.rb:13:in `call'
  app/controllers/credit_cards_controller.rb:14:in `initiate'
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
