### PR TITLE
[CAZ-2550] Not exempt declaration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,11 @@ gem 'turbolinks'
 gem 'webpacker'
 
 group :development, :test do
-  gem 'byebug'
   gem 'dotenv-rails'
   gem 'haml-rails'
+  gem 'jazz_fingers'
+  gem 'pry'
+  gem 'pry-rails'
   gem 'rspec-rails'
   gem 'scss_lint-govuk', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
+    awesome_print (1.8.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.305.0)
     aws-sdk-core (3.94.0)
@@ -106,6 +107,8 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    coolline (0.5.0)
+      unicode_utils (~> 1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -171,6 +174,11 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    jazz_fingers (5.0.1)
+      awesome_print (~> 1.6)
+      pry (~> 0.10)
+      pry-byebug (~> 3.4)
+      pry-coolline (~> 0.2)
     jmespath (1.4.0)
     json (2.3.0)
     listen (3.2.1)
@@ -202,6 +210,19 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-coolline (0.2.5)
+      coolline (~> 0.5)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -336,6 +357,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    unicode_utils (1.4.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.2)
@@ -382,7 +404,11 @@ DEPENDENCIES
   haml
   haml-rails
   httparty
+  jazz_fingers
   listen
+  pry
+  pry-rails
+  pry-stack_explorer
   puma
   rack_session_access
   rails (~> 6.0.2.2)

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -114,6 +114,21 @@ class PaymentsController < ApplicationController
   end
 
   ##
+  # Validates user has confirmed review payment.
+  # If it is valid, redirects to {select payment method page}[rdoc-ref:PaymentsController.select_payment_method]
+  # If not, renders {not found}[rdoc-ref:PaymentsController.review] with errors
+  #
+  # ==== Path
+  #    POST /payments/confirm_review
+  #
+  def confirm_review
+    form = ConfirmationForm.new(params['confirm-not-exemption'])
+    return redirect_to review_payments_path, alert: confirmation_error(form) unless form.valid?
+
+    redirect_to select_payment_method_payments_path
+  end
+
+  ##
   # Renders review details
   #
   # ==== Path

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -123,9 +123,12 @@ class PaymentsController < ApplicationController
   #
   def confirm_review
     form = ConfirmationForm.new(params['confirm-not-exemption'])
-    return redirect_to review_payments_path, alert: confirmation_error(form) unless form.valid?
 
-    redirect_to select_payment_method_payments_path
+    if form.valid?
+      redirect_to select_payment_method_payments_path
+    else
+      redirect_to review_payments_path, alert: confirmation_error(form)
+    end
   end
 
   ##

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -31,7 +31,7 @@ class UploadsController < ApplicationController
   def create
     file_name = UploadFile.call(file: params[:file], user: current_user)
     register_job(file_name)
-    redirect_to processing_uploads_path
+    redirect_to local_exemptions_vehicles_path(continue_path: processing_uploads_path)
   end
 
   ##

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -31,7 +31,7 @@ class UploadsController < ApplicationController
   def create
     file_name = UploadFile.call(file: params[:file], user: current_user)
     register_job(file_name)
-    redirect_to local_exemptions_vehicles_path(continue_path: processing_uploads_path)
+    redirect_to processing_uploads_path
   end
 
   ##
@@ -113,7 +113,7 @@ class UploadsController < ApplicationController
   def handle_successful_processing
     vrns_count = current_user.fleet.total_vehicles_count
     flash[:success] = I18n.t('vrn_form.messages.multiple_vrns_added', vrns_count: vrns_count)
-    redirect_to fleets_path
+    redirect_to local_exemptions_vehicles_path
   end
 
   # Handles failed scenario after CSV processing

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -11,7 +11,7 @@ class VehiclesController < ApplicationController
   rescue_from BaseApi::Error400Exception, with: :add_vehicle_exception
   # checks if VRN is present in the session
   before_action :check_vrn, only: %i[details confirm_details exempt incorrect_details not_found]
-  before_action :assign_back_button_url, only: %i[enter_details]
+  before_action :assign_back_button_url, only: %i[enter_details local_exemptions]
 
   ##
   # Renders the first step of checking the vehicle compliance.
@@ -128,7 +128,7 @@ class VehiclesController < ApplicationController
   # If not, renders {not found}[rdoc-ref:VehiclesController.not_found] with errors
   #
   # ==== Path
-  #    POST /vehicles/not_found
+  #    POST /vehicles/confirm_not_found
   #
   def confirm_not_found
     form = ConfirmationForm.new(params['confirm-registration'])
@@ -137,7 +137,21 @@ class VehiclesController < ApplicationController
     add_vehicle_to_fleet
   end
 
+  ##
+  # Renders the local vehicle exemptions page
+  #
+  # ==== Path
+  #    GET /vehicles/local_exemptions
+  #
+  def local_exemptions
+    @continue_path = local_exemptions_params[:continue_path] || fleets_path
+  end
+
   private
+
+  def local_exemptions_params
+    params.permit(:continue_path)
+  end
 
   # Check if vrn is present in the session
   def check_vrn
@@ -166,7 +180,7 @@ class VehiclesController < ApplicationController
     end
 
     session[:vrn] = nil
-    redirect_to fleets_path
+    redirect_to local_exemptions_vehicles_path
   end
 
   # Redirects to {vehicle not found}[rdoc-ref:VehiclesController.unrecognised_vehicle]

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -143,9 +143,7 @@ class VehiclesController < ApplicationController
   # ==== Path
   #    GET /vehicles/local_exemptions
   #
-  def local_exemptions
-    @continue_path = local_exemptions_params[:continue_path] || fleets_path
-  end
+  def local_exemptions; end
 
   private
 

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -72,4 +72,10 @@ module PaymentsHelper
   def formatted_date_string(date)
     Date.parse(date).strftime('%d %B %Y')
   end
+
+  # Returns exemption URL with proper title for given CAZ
+  def exemption_url_for(caz)
+    url_title = caz.name + ' City Council'
+    link_to(url_title, caz.exemption_url)
+  end
 end

--- a/app/models/clean_air_zone.rb
+++ b/app/models/clean_air_zone.rb
@@ -32,6 +32,11 @@ class CleanAirZone
     caz_data[:boundary_url]
   end
 
+  # Returns a string, eg. 'www.example.com'.
+  def exemption_url
+    caz_data[:exemption_url]
+  end
+
   # Checks if zones was already checked by user before.
   # Returns a boolean.
   def checked?(checked_zones)

--- a/app/views/payments/review.html.haml
+++ b/app/views/payments/review.html.haml
@@ -38,4 +38,26 @@
           %dd.govuk-summary-list__actions
             = link_to('View details', review_details_payments_path)
 
-      = link_to 'Continue', select_payment_method_payments_path, class: 'govuk-button'
+      = form_tag confirm_review_payments_path, method: :post do
+        .govuk-form-group{class: ('govuk-form-group--error' if alert)}
+          %fieldset.govuk-fieldset
+            %legend.govuk-visually-hidden
+              = I18n.t('payment_review.errors.confirmation_alert')
+
+            - if alert
+              %span#unrecognised-vehicle-error.govuk-error-message
+                %span.govuk-visually-hidden Error:
+                = I18n.t('payment_review.errors.confirmation_alert')
+
+            .govuk-checkboxes
+              .govuk-checkboxes__item
+                %input.govuk-checkboxes__input{name: 'confirm-not-exemption',
+                                          type: 'checkbox',
+                                          value: 'yes',
+                                          id: 'confirm-not-exemption'}
+                %label.govuk-label.govuk-checkboxes__label{for: 'confirm-not-exemption'}
+                  I confirm my vehicles are not exempt from paying the #{@zone.name} Clean Air Zone Charge.
+                  (Find out more about exemptions in #{link_to @zone.name + ' City Council', @zone.exemption_url})
+        
+        = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'
+

--- a/app/views/payments/review.html.haml
+++ b/app/views/payments/review.html.haml
@@ -52,9 +52,9 @@
             .govuk-checkboxes
               .govuk-checkboxes__item
                 %input.govuk-checkboxes__input{name: 'confirm-not-exemption',
-                                          type: 'checkbox',
-                                          value: 'yes',
-                                          id: 'confirm-not-exemption'}
+                                               type: 'checkbox',
+                                               value: 'yes',
+                                               id: 'confirm-not-exemption'}
                 %label.govuk-label.govuk-checkboxes__label{for: 'confirm-not-exemption'}
                   I confirm my vehicles are not exempt from paying the #{@zone.name} Clean Air Zone Charge.
                   (Find out more about exemptions in #{exemption_url_for(@zone)})

--- a/app/views/payments/review.html.haml
+++ b/app/views/payments/review.html.haml
@@ -57,7 +57,7 @@
                                           id: 'confirm-not-exemption'}
                 %label.govuk-label.govuk-checkboxes__label{for: 'confirm-not-exemption'}
                   I confirm my vehicles are not exempt from paying the #{@zone.name} Clean Air Zone Charge.
-                  (Find out more about exemptions in #{link_to @zone.name + ' City Council', @zone.exemption_url})
+                  (Find out more about exemptions in #{exemption_url_for(@zone)})
         
         = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'
 

--- a/app/views/vehicles/incorrect_details.html.haml
+++ b/app/views/vehicles/incorrect_details.html.haml
@@ -17,4 +17,4 @@
         If your vehicle does meet emission standards, you can claim a refund when your registration details are updated. 
       %p
         Continue to add the vehicle to your account.
-      = link_to 'Continue', fleets_path, class: 'govuk-button'
+      = link_to 'Continue', local_exemptions_vehicles_path, class: 'govuk-button'

--- a/app/views/vehicles/local_exemptions.html.haml
+++ b/app/views/vehicles/local_exemptions.html.haml
@@ -1,0 +1,16 @@
+- title_and_header = 'Local vehicle exemptions'
+- content_for(:title, title_and_header)
+
+= link_to 'Back', details_vehicles_path, class: 'govuk-back-link'
+
+%main.govuk-main-wrapper#main-content{role: 'main'}
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %h1.govuk-heading-l
+        = title_and_header
+      %p
+        Some vehicles which don't meet emissions standards still qualify for a temporary or permanent exemption from the Clean Air Zone charges.
+      %p
+        It is your responsibility to check if your vehicles are eligible for an exemption from the local authority in the Clean Air Zone you are driving in.
+
+      = link_to 'Continue', @continue_path, class: 'govuk-button'

--- a/app/views/vehicles/local_exemptions.html.haml
+++ b/app/views/vehicles/local_exemptions.html.haml
@@ -13,4 +13,4 @@
       %p
         It is your responsibility to check if your vehicles are eligible for an exemption from the local authority in the Clean Air Zone you are driving in.
 
-      = link_to 'Continue', @continue_path, class: 'govuk-button'
+      = link_to 'Continue', fleets_path, class: 'govuk-button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,3 +73,6 @@ en:
   vehicle_not_found:
     errors:
       confirmation_alert: Confirm the number plate is correct
+  payment_review:
+    errors:
+      confirmation_alert: Confirm you have checked if you are eligible for an exemption

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       post :matrix, to: 'payments#submit'
       get :clear_search
       get :review
+      post :confirm_review
       get :review_details
       get :select_payment_method
       post :select_payment_method, to: 'payments#confirm_payment_method'
@@ -87,6 +88,7 @@ Rails.application.routes.draw do
       get :incorrect_details
       get :not_found
       post :confirm_not_found
+      get :local_exemptions
     end
   end
 

--- a/features/debits.feature
+++ b/features/debits.feature
@@ -3,7 +3,25 @@ Feature: Debits
   As a user
   I want to manage my Direct Debits mandates
 
-  Scenario: Making a Direct Debit payment with active mandate
+  Scenario: Making a successful Direct Debit payment with active mandate
+    When I have active mandates for selected CAZ
+      And I visit the make payment page
+      And I press the Continue
+    Then I select 'Birmingham'
+      And I press the Continue
+    Then I click Next 7 days tab
+      And I select any date for vrn on the payment matrix
+      And I press the Continue
+    Then I want to confirm my payment
+      And I confirm that my vehicles are not exempt from payment
+      And I press the Continue
+    Then I select 'Direct Debit'
+      And I press the Continue
+    Then I should see 'Confirm your payment'
+      And I press 'Confirm payment' button
+    Then I should see success message
+
+  Scenario: Making a failure Direct Debit payment with active mandate
     When I have active mandates for selected CAZ
       And I visit the make payment page
       And I press the Continue
@@ -14,11 +32,8 @@ Feature: Debits
       And I press the Continue
     Then I want to confirm my payment
       And I press the Continue
-    Then I select 'Direct Debit'
-      And I press the Continue
-    Then I should see 'Confirm your payment'
-      And I press 'Confirm payment' button
-    Then I should see success message
+    Then I should be on the confirm payment page
+      And I should see 'Confirm you have checked if you are eligible for an exemption'
 
   Scenario: Visiting the manage Direct Debit page with no mandates
     When I have no mandates

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -33,6 +33,7 @@ Feature: Fleets
     Then I should be on the Charge details page
     When I press 'Return to review your payment' link
       And I want to confirm my payment
+      And I confirm that my vehicles are not exempt from payment
       And I press the Continue
     Then I should be on the Select payment method page
       And I press the Continue
@@ -56,6 +57,7 @@ Feature: Fleets
       And I press the Continue
     Then I should be on the confirm payment page
       And I want to confirm my payment without any active Direct Debit mandate
+      And I confirm that my vehicles are not exempt from payment
       And I press the Continue
     Then I should be on the success payment page
       And I should see success message

--- a/features/step_definitions/payments_steps.rb
+++ b/features/step_definitions/payments_steps.rb
@@ -26,6 +26,10 @@ When('I select any date for vrn on the payment matrix') do
   page.find('.govuk-checkboxes__input', match: :first).click
 end
 
+And('I confirm that my vehicles are not exempt from payment') do
+  page.find('#confirm-not-exemption').click
+end
+
 Then('I should be on the confirm payment page') do
   expect_path(review_payments_path)
 end

--- a/features/step_definitions/uploads_step.rb
+++ b/features/step_definitions/uploads_step.rb
@@ -21,12 +21,6 @@ Then('I should be on the processing page') do
   expect_path(processing_uploads_path)
 end
 
-# rubocop:disable Layout/LineLength
-Then('I should be on the local vehicles exemptions page with continue_path redirecting to processing page') do
-  expect_path(local_exemptions_vehicles_path(continue_path: processing_uploads_path))
-end
-# rubocop:enable Layout/LineLength
-
 Then('I should download the template') do
   expect(page.response_headers['Content-Type']).to eq('text/csv')
   expect(page.response_headers['Content-Disposition']).to include('VehicleUploadTemplate.csv')

--- a/features/step_definitions/uploads_step.rb
+++ b/features/step_definitions/uploads_step.rb
@@ -21,6 +21,12 @@ Then('I should be on the processing page') do
   expect_path(processing_uploads_path)
 end
 
+# rubocop:disable Layout/LineLength
+Then('I should be on the local vehicles exemptions page with continue_path redirecting to processing page') do
+  expect_path(local_exemptions_vehicles_path(continue_path: processing_uploads_path))
+end
+# rubocop:enable Layout/LineLength
+
 Then('I should download the template') do
   expect(page.response_headers['Content-Type']).to eq('text/csv')
   expect(page.response_headers['Content-Disposition']).to include('VehicleUploadTemplate.csv')

--- a/features/step_definitions/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_steps.rb
@@ -57,3 +57,7 @@ When('I press the Continue to add vehicle') do
   mock_vehicles_in_fleet
   click_on 'Continue'
 end
+
+Then('I should be on the local vehicles exemptions page') do
+  expect_path(local_exemptions_vehicles_path)
+end

--- a/features/uploads.feature
+++ b/features/uploads.feature
@@ -11,6 +11,8 @@ Feature: Uploads
     Then I should see "Select a file" 2 times
     When I attach a file
       And I press upload
+    Then I should be on the local vehicles exemptions page with continue_path redirecting to processing page
+    When I press "Continue" link
     Then I should be on the processing page
     When I reload the page
     Then I should be on the processing page
@@ -21,6 +23,8 @@ Feature: Uploads
     Then I should see "Replace and upload a new list of vehicles"
     When I attach a file
       And I press upload
+    Then I should be on the local vehicles exemptions page with continue_path redirecting to processing page
+    When I press "Continue" link
     Then I should be on the processing page
 
   Scenario: Download template

--- a/features/uploads.feature
+++ b/features/uploads.feature
@@ -11,11 +11,15 @@ Feature: Uploads
     Then I should see "Select a file" 2 times
     When I attach a file
       And I press upload
-    Then I should be on the local vehicles exemptions page with continue_path redirecting to processing page
-    When I press "Continue" link
     Then I should be on the processing page
     When I reload the page
     Then I should be on the processing page
+      And My upload is successful
+      And I reload the page
+    Then I should be on the local vehicles exemptions page
+      And I press "Continue" link
+    Then I should be on the manage vehicles page
+      And I should see 'You have successfully uploaded'
 
   Scenario: Uploading file with vehicles in the fleets
     When I have vehicles in my fleet
@@ -23,9 +27,11 @@ Feature: Uploads
     Then I should see "Replace and upload a new list of vehicles"
     When I attach a file
       And I press upload
-    Then I should be on the local vehicles exemptions page with continue_path redirecting to processing page
-    When I press "Continue" link
     Then I should be on the processing page
+      And My upload is successful
+      And I reload the page
+    Then I should be on the local vehicles exemptions page
+      And I press "Continue" link
 
   Scenario: Download template
     When I have no vehicles in my fleet
@@ -38,6 +44,8 @@ Feature: Uploads
     When I am on the processing page
       And My upload is successful
       And I reload the page
+    Then I should be on the local vehicles exemptions page
+      And I press "Continue" link
     Then I should be on the manage vehicles page
       And I should see 'You have successfully uploaded'
 

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -13,6 +13,8 @@ Feature: Vehicles
     Then I should be on the details page
     When I choose that the details are correct
       And I press the Confirm
+    Then I should be on the local vehicles exemptions page
+    When I press "Continue" link
     Then I should be on the manage vehicles page
 
   Scenario: Submitting empty vrn
@@ -26,6 +28,8 @@ Feature: Vehicles
       And I press the Continue
     Then I should be on the exempt page
     When I press the Continue to add vehicle
+    Then I should be on the local vehicles exemptions page
+    When I press "Continue" link
     Then I should be on the manage vehicles page
 
   Scenario: Adding the not found vehicle
@@ -40,6 +44,8 @@ Feature: Vehicles
       And I should be on the vehicle not found page
       And I check "I confirm the number plate is correct and I want to add it to my account."
     When I press the Continue to add vehicle
+    Then I should be on the local vehicles exemptions page
+    When I press "Continue" link
     Then I should be on the manage vehicles page
 
   Scenario: Adding a vehicle with incorrect details

--- a/spec/models/clean_air_zones_spec.rb
+++ b/spec/models/clean_air_zones_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe CleanAirZone, type: :model do
   subject(:caz) { described_class.new(data) }
 
-  let(:data) { { 'name' => name, 'cleanAirZoneId' => id, 'boundaryUrl' => url } }
+  let(:data) do
+    { 'name' => name, 'cleanAirZoneId' => id, 'boundaryUrl' => url, 'exemptionUrl' => url }
+  end
   let(:name) { 'Birmingham' }
   let(:id) { 'a49afb83-d1b3-48b6-b08b-5db8142045dc' }
   let(:url) { 'www.example.com' }
@@ -25,6 +27,12 @@ describe CleanAirZone, type: :model do
   describe '.boundary_url' do
     it 'returns a proper url' do
       expect(caz.boundary_url).to eq(url)
+    end
+  end
+
+  describe '.exemption_url' do
+    it 'returns a proper url' do
+      expect(caz.exemption_url).to eq(url)
     end
   end
 

--- a/spec/requests/uploads/create_spec.rb
+++ b/spec/requests/uploads/create_spec.rb
@@ -23,8 +23,7 @@ describe 'UploadsController - #index' do
 
   it 'redirects to #processing' do
     http_request
-    continue_path = local_exemptions_vehicles_path(continue_path: processing_uploads_path)
-    expect(response).to redirect_to(continue_path)
+    expect(response).to redirect_to(processing_uploads_path)
   end
 
   it 'sets filename in the session' do

--- a/spec/requests/uploads/create_spec.rb
+++ b/spec/requests/uploads/create_spec.rb
@@ -23,7 +23,8 @@ describe 'UploadsController - #index' do
 
   it 'redirects to #processing' do
     http_request
-    expect(response).to redirect_to(processing_uploads_path)
+    continue_path = local_exemptions_vehicles_path(continue_path: processing_uploads_path)
+    expect(response).to redirect_to(continue_path)
   end
 
   it 'sets filename in the session' do

--- a/spec/requests/uploads/processing_spec.rb
+++ b/spec/requests/uploads/processing_spec.rb
@@ -45,8 +45,8 @@ describe 'UploadsController - #processing' do
       end
 
       describe 'success' do
-        it 'returns redirect to fleets_path' do
-          expect(response).to redirect_to(fleets_path)
+        it 'returns redirect to local_exemptions_vehicles_path' do
+          expect(response).to redirect_to(local_exemptions_vehicles_path)
         end
 
         it 'clears job data' do

--- a/spec/requests/vehicles/confirm_details_spec.rb
+++ b/spec/requests/vehicles/confirm_details_spec.rb
@@ -32,9 +32,9 @@ describe 'VehicleCheckersController - POST #confirm_details', type: :request do
       end
 
       context 'when user confirms details' do
-        it 'redirects to fleets' do
+        it 'redirects to local vehicle exemptions' do
           http_request
-          expect(response).to redirect_to(fleets_path)
+          expect(response).to redirect_to(local_exemptions_vehicles_path)
         end
 
         it 'adds the vehicle to the fleet' do

--- a/spec/requests/vehicles/confirm_not_found_spec.rb
+++ b/spec/requests/vehicles/confirm_not_found_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'VehiclesController - POST #confirm_not_found', type: :request do
       end
 
       it 'redirects to manage vehicles page' do
-        expect(response).to redirect_to(fleets_path)
+        expect(response).to redirect_to(local_exemptions_vehicles_path)
       end
     end
 

--- a/spec/requests/vehicles/enter_details_spec.rb
+++ b/spec/requests/vehicles/enter_details_spec.rb
@@ -5,7 +5,5 @@ require 'rails_helper'
 describe 'VehiclesController - #enter_details', type: :request do
   subject(:http_request) { get enter_details_vehicles_path }
 
-  let(:no_vrn_path) { enter_details_vehicles_path }
-
   it_behaves_like 'a login required view'
 end

--- a/spec/requests/vehicles/local_exemptions_spec.rb
+++ b/spec/requests/vehicles/local_exemptions_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'VehiclesController - #local_exemptions', type: :request do
+  subject(:http_request) { get local_exemptions_vehicles_path }
+
+  let(:no_vrn_path) { local_exemptions_vehicles_path }
+
+  it_behaves_like 'a login required view'
+end

--- a/spec/requests/vehicles/local_exemptions_spec.rb
+++ b/spec/requests/vehicles/local_exemptions_spec.rb
@@ -5,7 +5,5 @@ require 'rails_helper'
 describe 'VehiclesController - #local_exemptions', type: :request do
   subject(:http_request) { get local_exemptions_vehicles_path }
 
-  let(:no_vrn_path) { local_exemptions_vehicles_path }
-
   it_behaves_like 'a login required view'
 end


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2550

## Description
Redirect to a page that informs about local exemptions during add new vehicles via CSV or manually.

## How Has This Been Tested?
Manually, new RSpec and cucumber test added, existing fixed to reflect changes in the flow.

## Screenshots (if appropriate):
![Zrzut ekranu z 2020-05-08 13-47-04](https://user-images.githubusercontent.com/1614426/81403071-eb485580-9132-11ea-81cb-9ddc1728df93.png)
![Zrzut ekranu z 2020-05-08 13-48-23](https://user-images.githubusercontent.com/1614426/81403076-ec798280-9132-11ea-8099-817bc47f4a3a.png)

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

