### PR TITLE
[CAZ-2550] Add missing 'error-summary-title'

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -122,7 +122,7 @@ class PaymentsController < ApplicationController
   #    POST /payments/confirm_review
   #
   def confirm_review
-    form = ConfirmationForm.new(params['confirm-not-exemption'])
+    form = PaymentReviewForm.new(params['confirm-not-exemption'])
 
     if form.valid?
       redirect_to select_payment_method_payments_path

--- a/app/forms/payment_review_form.rb
+++ b/app/forms/payment_review_form.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+##
+# This class is used to validate user data filled in +app/views/users/manage.html.haml+.
+class PaymentReviewForm
+  include ActiveModel::Validations
+
+  # form confirmation from the query params, values: 'yes', 'no', nil
+  attr_reader :confirmation
+
+  validates :confirmation, inclusion: {
+    in: %w[yes], message: I18n.t('payment_review.errors.confirmation_alert')
+  }
+
+  ##
+  # Initializer method
+  #
+  # ==== Attributes
+  #
+  # * +confirmation+ - string, eg. 'yes'
+  #
+  def initialize(confirmation)
+    @confirmation = confirmation
+  end
+
+  # Checks if +confirmation+ equality to 'yes'.
+  #
+  # Returns a boolean.
+  def confirmed?
+    confirmation == 'yes'
+  end
+end

--- a/app/views/payments/review.html.haml
+++ b/app/views/payments/review.html.haml
@@ -6,6 +6,11 @@
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds
+      - if alert
+        = render 'common/error_summary',
+          error_msg_div: '#govuk-error-message',
+          error_msg: alert
+
       %h1.govuk-heading-l
         = title_and_header
 

--- a/spec/forms/payment_review_form_spec.rb
+++ b/spec/forms/payment_review_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PaymentReviewForm, type: :model do
+  subject(:form) { described_class.new(confirmation) }
+
+  let(:confirmation) { 'yes' }
+
+  it { is_expected.to be_valid }
+
+  describe '.confirmed?' do
+    context 'when confirmation equals yes' do
+      it 'returns true' do
+        expect(form.confirmed?).to eq(true)
+      end
+    end
+  end
+
+  context 'when confirmation is empty' do
+    let(:confirmation) { '' }
+    let(:error_message) { I18n.t('payment_review.errors.confirmation_alert') }
+
+    it { is_expected.not_to be_valid }
+
+    before do
+      form.valid?
+    end
+
+    it 'has a proper error message' do
+      expect(form.errors.messages[:confirmation]).to include(error_message)
+    end
+  end
+end

--- a/spec/forms/payment_review_form_spec.rb
+++ b/spec/forms/payment_review_form_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 describe PaymentReviewForm, type: :model do
   subject(:form) { described_class.new(confirmation) }
 
-  let(:confirmation) { 'yes' }
+  before { form.valid? }
 
-  it { is_expected.to be_valid }
+  context 'when confirmation equals yes' do
+    let(:confirmation) { 'yes' }
 
-  describe '.confirmed?' do
-    context 'when confirmation equals yes' do
+    it { is_expected.to be_valid }
+
+    describe '.confirmed?' do
       it 'returns true' do
         expect(form.confirmed?).to eq(true)
       end
@@ -19,15 +21,11 @@ describe PaymentReviewForm, type: :model do
 
   context 'when confirmation is empty' do
     let(:confirmation) { '' }
-    let(:error_message) { I18n.t('payment_review.errors.confirmation_alert') }
 
     it { is_expected.not_to be_valid }
 
-    before do
-      form.valid?
-    end
-
     it 'has a proper error message' do
+      error_message = I18n.t('payment_review.errors.confirmation_alert')
       expect(form.errors.messages[:confirmation]).to include(error_message)
     end
   end


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2550

## Description
Add missing `error-summary-title` to the page

## How Has This Been Tested?
Manually, one new spec added.

## Screenshots (if appropriate):
![Screenshot_20200514_091833](https://user-images.githubusercontent.com/1614426/81904846-24b21280-95c4-11ea-821b-13d4a9adfb6a.png)

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
