### PR TITLE
[CAZ-2686] Remediate plate numbers being logged in service logs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -139,7 +139,7 @@ steps:
     pull: never
     commands:
       - bundle audit check --update
-      - yarn run improved-yarn-audit --exclude '1500' --retry-on-network-failure
+      - yarn run improved-yarn-audit --exclude '1500, 1486' --retry-on-network-failure
       - brakeman
     volumes:
       - name: docker_sock
@@ -360,7 +360,7 @@ steps:
     pull: never
     commands:
       - bundle audit check --update
-      - yarn run improved-yarn-audit --exclude '1500' --retry-on-network-failure
+      - yarn run improved-yarn-audit --exclude '1500, 1486' --retry-on-network-failure
       - brakeman
     volumes:
       - name: docker_sock
@@ -606,7 +606,7 @@ steps:
     pull: never
     commands:
       - bundle audit check --update
-      - yarn run improved-yarn-audit --exclude '1500' --retry-on-network-failure
+      - yarn run improved-yarn-audit --exclude '1500, 1486' --retry-on-network-failure
       - brakeman
     volumes:
       - name: docker_sock
@@ -858,7 +858,7 @@ steps:
     pull: never
     commands:
       - bundle audit check --update
-      - yarn run improved-yarn-audit --exclude '1500' --retry-on-network-failure
+      - yarn run improved-yarn-audit --exclude '1500, 1486' --retry-on-network-failure
       - brakeman
     volumes:
       - name: docker_sock

--- a/app/api_wrappers/compliance_checker_api.rb
+++ b/app/api_wrappers/compliance_checker_api.rb
@@ -48,7 +48,7 @@ class ComplianceCheckerApi < BaseApi
     # * {500 Exception}[rdoc-ref:BaseApi::Error500Exception] - backend API error
     #
     def vehicle_details(vrn)
-      log_action "Getting vehicle details, vrn: #{vrn}"
+      log_action 'Getting vehicle details'
       request(:get, "/vehicles/#{vrn}/details")
     end
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -11,4 +11,9 @@ Rails.application.config.filter_parameters += %i[
   account_name
   login_ip
   vrn
+  authenticity_token
+  vrm
+  plate_number
+  license_number
+  vehicles
 ]


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2686

## Description
Add additional parameters to the `filtered_params`. Investigate logged things.

## How Has This Been Tested?
Manually, by trying each action in the system and watching the logs.

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
