### PR TITLE
[CAZ-2707] Do not display CAZ during payment when CAZ is not chargeable

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -22,7 +22,7 @@ class PaymentsController < ApplicationController
   def index
     return redirect_to first_upload_fleets_path if current_user.fleet.total_vehicles_count < 2
 
-    @zones = CleanAirZone.all
+    @zones = CleanAirZone.active
   end
 
   ##

--- a/app/models/clean_air_zone.rb
+++ b/app/models/clean_air_zone.rb
@@ -55,6 +55,11 @@ class CleanAirZone
                                  .sort_by(&:name)
   end
 
+  # Fetches active for charging CAZs from ComplianceCheckerApi.clean_air_zones endpoint
+  def self.active
+    all.reject { |caz| caz.active_charge_start_date.future? }
+  end
+
   # Finds a zone by given ID
   def self.find(id)
     all.find { |caz| caz.id == id }

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -93,3 +93,12 @@ Feature: Fleets
       And I should see 'Next 7 days'
       And I should not see 'Past'
 
+  Scenario: Checking selectable only active for charging CAZ list during payment.
+    When I want to pay for active for charging CAZ
+      And I visit the make payment page
+      And I press the Continue
+    Then I should be on the make a payment page
+      And I should see 'Which Clean Air Zone do you need to pay for?'
+      And I should see 'Birmingham'
+      And I should not see 'Leeds'
+

--- a/features/step_definitions/fleets_steps.rb
+++ b/features/step_definitions/fleets_steps.rb
@@ -57,6 +57,12 @@ When('I want to pay for CAZ which started charging {int} days ago') do |start_da
   mock_unpaid_vehicles_in_fleet
 end
 
+When('I want to pay for active for charging CAZ') do
+  caz_list = read_response('caz_list_active.json')['cleanAirZones']
+  mock_clean_air_zones(caz_list)
+  mock_unpaid_vehicles_in_fleet
+end
+
 When('I have vehicles in my fleet that are not paid') do
   mock_clean_air_zones
   mock_unpaid_vehicles_in_fleet

--- a/spec/fixtures/responses/caz_list_active.json
+++ b/spec/fixtures/responses/caz_list_active.json
@@ -1,0 +1,16 @@
+{
+  "cleanAirZones": [
+    {
+      "cleanAirZoneId": "5cd7441d-766f-48ff-b8ad-1809586fea37",
+      "name": "Birmingham",
+      "boundaryUrl": "https://www.birmingham.gov.uk/info/20076/pollution/1763/a_clean_air_zone_for_birmingham/3",
+      "activeChargeStartDate": "2020-05-14"
+    },
+    {
+      "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
+      "name": "Leeds",
+      "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
+      "activeChargeStartDate": "2222-05-14"
+    }
+  ]
+}

--- a/spec/models/clean_air_zones_spec.rb
+++ b/spec/models/clean_air_zones_spec.rb
@@ -74,5 +74,31 @@ describe CleanAirZone, type: :model do
     it 'returns an array of CleanAirZone instances' do
       expect(zones).to all(be_a(CleanAirZone))
     end
+
+    it 'returns only active CleanAirZone' do
+      expect(zones.count).to eq(2)
+    end
+  end
+
+  describe '.active' do
+    subject(:zones) { described_class.active }
+
+    before do
+      caz_list = read_response('caz_list_active.json')['cleanAirZones']
+      allow(ComplianceCheckerApi).to receive(:clean_air_zones).and_return(caz_list)
+      CleanAirZone.remove_instance_variable :@all if CleanAirZone.instance_variable_defined? :@all
+    end
+
+    after do
+      CleanAirZone.remove_instance_variable :@all if CleanAirZone.instance_variable_defined? :@all
+    end
+
+    it 'returns an array of CleanAirZone instances' do
+      expect(zones).to all(be_a(CleanAirZone))
+    end
+
+    it 'returns only active CleanAirZone' do
+      expect(zones.count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZ-2707

## Description
<!--- Describe your changes in detail -->
Changed the scope of Clean Air Zones in select during the payment process to allow only to pay for the CAZ which is chargeable. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the `activeChargeStartDate` of Leeds CAZ
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/998642/82671462-2ec8b680-9c3f-11ea-8e58-65b6adb96d9d.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
