### PR TITLE
[CAZ-2576] Make link to city councils an external one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bundler-audit'
 gem 'devise'
 gem 'haml'
 gem 'httparty'
-gem 'puma'
+gem 'puma', '>= 4.3.5'
 gem 'redis'
 gem 'rubocop-rails'
 gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.3)
+    puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.2)
     rack-proxy (0.6.5)
@@ -404,7 +404,7 @@ DEPENDENCIES
   listen
   pry
   pry-rails
-  puma
+  puma (>= 4.3.5)
   rack_session_access
   rails (~> 6.0.3.1)
   rails-controller-testing

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -81,6 +81,6 @@ module PaymentsHelper
   # Returns exemption URL with proper title for given CAZ
   def exemption_url_for(caz)
     url_title = caz.name + ' City Council'
-    link_to(url_title, caz.exemption_url)
+    external_link_to(url_title, caz.exemption_url)
   end
 end


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2576?focusedCommentId=214418

## Description
Link to city councils were without `open in new window` addnotation.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![Screenshot_20200525_070255](https://user-images.githubusercontent.com/1614426/82779942-d9b2bd80-9e55-11ea-9289-f143d0e218dd.png)

## Checklist:
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
