### PR TITLE
[CAZ-2662] Allow to go back and change Company Name in Account creation

### DIFF
--- a/app/services/session_manipulation/set_account_id.rb
+++ b/app/services/session_manipulation/set_account_id.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+##
+# Module used to improve session management during the payment process
+#
+module SessionManipulation
+  ##
+  # Service used to set Company Name provided by user in the first step of sign up.
+  #
+  class SetAccountId < BaseManipulator
+    # Adds the +account_id+ to the session. Used by the class level method +.call+
+    def call
+      session[:new_account] ||= {}
+      session[:new_account]['account_id'] = params['account_id']
+    end
+  end
+end

--- a/app/views/organisations/fleet_check.html.haml
+++ b/app/views/organisations/fleet_check.html.haml
@@ -1,6 +1,8 @@
 - title_and_header = 'How many vehicles do you manage or own?'
 - content_for(:title, title_and_header)
 
+= link_to 'Back', organisations_path, class: 'govuk-back-link'
+
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -13,6 +13,10 @@ Feature: Organisations
     Then I enter a company name
       And I press the Continue
     Then I should see "How many vehicles do you manage or own?"
+      And I press the Back link
+    Then I should see "Create an account"
+      And I press the Continue
+    Then I should see "How many vehicles do you manage or own?"
       And I choose "Two or more"
       And I press the Continue
     Then I should see "Sign in details"

--- a/spec/requests/organisations/set_name_spec.rb
+++ b/spec/requests/organisations/set_name_spec.rb
@@ -12,11 +12,62 @@ describe 'OrganisationsController - POST #set_name' do
   context 'with valid params' do
     before do
       allow(CreateAccount).to receive(:call).and_return(SecureRandom.uuid)
-      subject
     end
 
-    it 'returns a success response' do
-      expect(response).to have_http_status(:found)
+    context 'when account_id not present in session' do
+      it 'returns a found response' do
+        subject
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'calls CreateAccount service response' do
+        subject
+        expect(CreateAccount).to have_received(:call)
+      end
+    end
+
+    context 'when account_id present in session but name has been changed' do
+      before do
+        add_to_session(new_account: new_account_session)
+        subject
+      end
+
+      let(:new_account_session) do
+        {
+          'account_id' => '76155935-33cb-4bb8-991a-e014621697be',
+          'company_name' => 'Other Company Name'
+        }
+      end
+
+      it 'returns a found response' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'calls CreateAccount service response' do
+        expect(CreateAccount).to have_received(:call)
+      end
+    end
+
+    context 'when account_id present in session and name has not been changed' do
+      before do
+        add_to_session(new_account: new_account_session)
+        subject
+      end
+
+      let(:new_account_session) do
+        {
+          'account_id' => '76155935-33cb-4bb8-991a-e014621697be',
+          'company_name' => company_name
+        }
+      end
+
+      it 'returns a found response' do
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'does not call CreateAccount service response' do
+        expect(CreateAccount).not_to have_received(:call)
+      end
     end
   end
 

--- a/spec/services/session_manipulation/set_account_id_spec.rb
+++ b/spec/services/session_manipulation/set_account_id_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionManipulation::SetAccountId do
+  subject(:service) do
+    described_class.call(session: session, params: { 'account_id' => account_id })
+  end
+
+  let(:session) { { company_name: {} } }
+  let(:account_id) { '95d475c7-a39f-4752-b61e-c0269ceaa4c8' }
+
+  it 'sets new_account account_id' do
+    service
+    expect(session[:new_account]['account_id']).to eq(account_id)
+  end
+end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZ-2662

## Description
<!--- Describe your changes in detail -->
Updated the account creation process.
Added back button to the first step. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**Given** the session does not have an account ID or a company name
**When** I submit the company name
**Then** I am shown the “Enter your sign in details” page

**Given** the session has an account ID and a company name
**When** I submit a new company name
**And** the company name is different from the previous name
**Then** I call the account creation endpoint with the new name

**Given** the session has an account ID and a company name
**When** I submit the same company name
**Then** I am shown the “Enter your sign in details” page

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
