### PR TITLE
[CAZ-2801] Add support for resend email link

### DIFF
--- a/app/api_wrappers/accounts_api.rb
+++ b/app/api_wrappers/accounts_api.rb
@@ -132,6 +132,40 @@ class AccountsApi < BaseApi
     end
 
     ##
+    # Calls +/v1/accounts/:accountId/users/:accountUserId/verifications+ endpoint with +POST+ method.
+    #
+    # ==== Attributes
+    #
+    # * +account_id+ - uuid, ID of the account on backend DB
+    # * +user_id+ - uuid, ID of the accountUser on backend DB
+    # * +verification_url+ - url to verify account.
+    #
+    # ==== Example
+    #
+    #     AccountsApi.resend_verification(
+    #       account_id: user.account_id,
+    #       user_id: user.user_id
+    #       verification_url: 'http://exmaple.url'
+    #     )
+    #
+    # ==== Result
+    #
+    # Returns an empty body
+    #
+    # ==== Exceptions
+    #
+    # * {404 Exception}[rdoc-ref:BaseApi::Error404Exception] - user not found
+    # * {500 Exception}[rdoc-ref:BaseApi::Error500Exception] - backend API error
+    #
+    def resend_verification(account_id:, user_id:, verification_url:)
+      log_action 'Resend verification email of user account'
+      # body = { verificationUrl: verification_url }.to_json
+      # request(:post, "/accounts/#{account_id}/users/#{user_id}/verifications", body: body)
+      "Mock success request (account_id: #{account_id}, user_id: #{user_id},
+       verification_url: #{verification_url})"
+    end
+
+    ##
     # Calls +/v1/accounts/:accountId/users/:accountUserId/verify+ endpoint with +POST+ method.
     #
     # ==== Attributes

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/ClassLength
 class OrganisationsController < ApplicationController
   skip_before_action :authenticate_user!
-  # checks if company name is present in session
+  # checks if new_company account_id is present in session
   before_action :check_account_id, only: %i[new_credentials create email_sent]
   # checks if new account details is present in session
   before_action :check_account_details, only: %i[email_sent resend_email]
@@ -129,8 +129,11 @@ class OrganisationsController < ApplicationController
   end
 
   def resend_email
-    # TODO: Missing endpoint for back-end to resend an email
-    # user = User.new(new_account)
+    AccountsApi.resend_verification(
+      account_id: new_account['account_id'],
+      user_id: new_account['user_id'],
+      verification_url: email_verification_organisations_url
+    )
     redirect_to email_sent_organisations_path
   end
 

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -29,6 +29,10 @@ Feature: Organisations
     Then I enter the account details
       And I press the Continue
       And I should see "Verification email"
+    Then I want to resend email verification
+      And I press "resend the email" link
+      And I receive verification email
+      And I should see "Verification email"
 
   Scenario: User tries to create invalid company
     Given I go to the create account page

--- a/features/step_definitions/organisations_steps.rb
+++ b/features/step_definitions/organisations_steps.rb
@@ -59,6 +59,14 @@ And('I enter the account details with not uniq email address') do
   fill_account_details
 end
 
+Then('I want to resend email verification') do
+  allow(AccountsApi).to receive(:resend_verification).and_return(true)
+end
+
+And('I receive verification email') do
+  expect(AccountsApi).to have_received(:resend_verification)
+end
+
 When('I go to the email verified page') do
   visit email_verified_organisations_path
 end

--- a/spec/api_wrappers/accounts_api/resend_verification_spec.rb
+++ b/spec/api_wrappers/accounts_api/resend_verification_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'AccountsApi.create_account', skip: 'MOCKED REQUEST' do
+  subject(:call) do
+    AccountsApi.resend_verification(
+      account_id: account_id,
+      user_id: user_id,
+      verification_url: verification_url
+    )
+  end
+
+  let(:account_id) { '4d9ed7eb-14b3-4452-93d9-53ac180322ff' }
+  let(:user_id) { '798f07f1-92a7-47d4-b456-60d149369c7b' }
+  let(:verification_url) { 'http://example.url' }
+  let(:base_url) { "/accounts/#{account_id}/users/#{user_id}/verifications" }
+
+  context 'when the response status is 200' do
+    before { stub_request(:post, /#{base_url}/).to_return(status: 200) }
+
+    it 'returns proper fields' do
+      expect(call).to be_truthy
+    end
+
+    it 'calls API with proper body' do
+      body = { verificationUrl: verification_url }
+      call
+      expect(WebMock).to have_requested(:post, /#{base_url}/).with(body: body).once
+    end
+  end
+
+  context 'when the response status is 404' do
+    before do
+      stub_request(:post, /#{base_url}/).to_return(
+        status: 404,
+        body: { 'message' => 'Account id not found' }.to_json
+      )
+    end
+
+    it 'raises Error404Exception' do
+      expect { call }.to raise_exception(BaseApi::Error404Exception)
+    end
+  end
+end

--- a/spec/requests/organisations/resend_email_spec.rb
+++ b/spec/requests/organisations/resend_email_spec.rb
@@ -12,6 +12,12 @@ describe 'OrganisationsController - GET #resend_email' do
 
   before do
     add_to_session(session_data)
+    allow(AccountsApi).to receive(:resend_verification).and_return(true)
+  end
+
+  it 'calls AccountApi to resend the email' do
+    subject
+    expect(AccountsApi).to have_received(:resend_verification)
   end
 
   it 'returns a redirect to email_sent' do
@@ -21,6 +27,11 @@ describe 'OrganisationsController - GET #resend_email' do
 
   context 'without new_account data in the session' do
     let(:session_data) { { new_account: { 'account_id': SecureRandom.uuid } } }
+
+    it 'does not call AccountApi to resend the email' do
+      subject
+      expect(AccountsApi).not_to have_received(:resend_verification)
+    end
 
     it 'returns a redirect to root_path' do
       subject


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZ-2801
Added support for new (not implemented yet) endpoint to resend verification email.

## Description
<!--- Describe your changes in detail -->
I commented out the request to don't call not implemented endpoint. 
We will uncomment it when https://eaflood.atlassian.net/browse/CAZ-2803 is ready.

## How Has This Been Tested?
Added Feature and Unit tests. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/998642/83107062-da4d8d00-a0bd-11ea-9a5b-70b5fa201ab9.png)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
