### PR TITLE
Update check_build_number.sh

### DIFF
--- a/build_utils/check_build_number.sh
+++ b/build_utils/check_build_number.sh
@@ -7,7 +7,7 @@ echo "Checking build number on remote host"
 until [ $check = "true" ]
 do
 
-if curl -s "$build_id_url" | grep "$build_id";
+if curl -s "$build_id_url" | grep -w "$build_id";
 then
     echo "Build id found"
     exit


### PR DESCRIPTION
Add -w argument to grep command to avoid partial matches on build numbers.
* https://stackoverflow.com/questions/19576292/display-exact-matches-only-with-grep/19576374
* Tested by cURL on pre-production with exported build numbers.