### PR TITLE
[CAZ-2809] Show D-Day notice if charge start day is today too

### DIFF
--- a/app/services/payment_dates.rb
+++ b/app/services/payment_dates.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class PaymentDates < BaseService
-  # Attribute accessor used in {matrix}[rdoc-ref:PaymentsController.matrix]
-  attr_accessor :d_day_notice
-
   # date format used to display on the UI, eg. 'Fri 11 Oct'
   DISPLAY_DATE_FORMAT = '%a %d %b'
   # date format used to communicate with backend API, eg. '2019-05-14'
@@ -29,6 +26,11 @@ class PaymentDates < BaseService
     }
   end
 
+  # Checks if D-Day notice should be shown
+  def d_day_notice
+    charge_start_date >= past_start_date
+  end
+
   private
 
   attr_reader :charge_start_date
@@ -50,16 +52,10 @@ class PaymentDates < BaseService
     (past_start_date..past_end_date).map { |date| parse(date) }
   end
 
-  # set past dates start date and assigns +d_day_notice+
+  # set past dates start date
   def past_start_date
     past_start_date = Date.today - 6.days
-    if charge_start_date > past_start_date
-      @d_day_notice = true
-      charge_start_date
-    else
-      @d_day_notice = false
-      past_start_date
-    end
+    past_start_date < charge_start_date ? charge_start_date : past_start_date
   end
 
   # set past dates end date

--- a/features/payments.feature
+++ b/features/payments.feature
@@ -93,10 +93,10 @@ Feature: Fleets
     Then I should be on the payment matrix page
       And I should see 'Next 7 days'
       And I should not see 'Past'
-      And I should not see "Why can't I see my date?"
+      And I should see "Why can't I see my date?"
 
   Scenario: Visiting the the matrix for caz which stared charging five days ago
-    When I want to pay for CAZ which started charging 5 days ago
+    When I want to pay for CAZ which started charging 6 days ago
       And I visit the make payment page
       And I press the Continue
     Then I select 'Birmingham'
@@ -104,7 +104,7 @@ Feature: Fleets
       And I should see "Why can't I see my date?"
 
   Scenario: Visiting the the matrix for caz which stared charging six days ago
-    When I want to pay for CAZ which started charging 6 days ago
+    When I want to pay for CAZ which started charging 7 days ago
       And I visit the make payment page
       And I press the Continue
     Then I select 'Birmingham'

--- a/spec/services/payment_dates_spec.rb
+++ b/spec/services/payment_dates_spec.rb
@@ -92,29 +92,29 @@ describe PaymentDates do
       context 'when #charge_start_date is tomorrow' do
         let(:charge_start_date) { Date.current.tomorrow }
 
-        it 'returns nil' do
-          expect(service.d_day_notice).to be_nil
+        it 'returns true' do
+          expect(service.d_day_notice).to be_truthy
         end
       end
 
       context 'and #charge_start_date is today' do
         let(:charge_start_date) { Date.current }
 
-        it 'returns nil' do
-          expect(service.d_day_notice).to be_nil
+        it 'returns true' do
+          expect(service.d_day_notice).to be_truthy
         end
       end
 
       context 'and #charge_start_date is more than a week in the future' do
         let(:charge_start_date) { 1.day.from_now }
 
-        it 'returns nil' do
-          expect(service.d_day_notice).to be_nil
+        it 'returns true' do
+          expect(service.d_day_notice).to be_truthy
         end
       end
 
       context 'when #charge_start_date is not considered' do
-        let(:charge_start_date) { Date.today - 6.days }
+        let(:charge_start_date) { Date.today - 7.days }
 
         it 'returns false' do
           expect(service.d_day_notice).to be_falsey


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2809
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![d_day](https://user-images.githubusercontent.com/24584219/84160839-eb5bae00-aa6e-11ea-98fa-81e0f360b3e0.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
