### PR TITLE
[CAZ-2867] Omit local exemption page for globally exempted vehicles

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -99,7 +99,6 @@ class VehiclesController < ApplicationController
   def confirm_and_add_exempt_vehicle_to_fleet
     form = ConfirmationForm.new(confirmation)
     return redirect_to details_vehicles_path, alert: confirmation_error(form) unless form.valid?
-
     return redirect_to incorrect_details_vehicles_path unless form.confirmed?
 
     add_to_current_users_fleet

--- a/app/views/vehicles/exempt.html.haml
+++ b/app/views/vehicles/exempt.html.haml
@@ -18,6 +18,7 @@
                            class: 'caz-inline-link',
                            id: 'transport-for-london')
         if you need to drive in London.
-      = form_tag confirm_details_vehicles_path, method: :post do
+
+      = form_tag confirm_and_add_exempt_vehicle_to_fleet_vehicles_path, method: :post do
         %input{name: 'confirm-vehicle', type: 'hidden', value: 'yes'}
         = submit_tag 'Continue', class: 'govuk-button', 'data-module': 'govuk-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
       post :confirm_not_found
       get :local_exemptions
       post :add_to_fleet
+      post :confirm_and_add_exempt_vehicle_to_fleet
     end
   end
 

--- a/features/vehicles.feature
+++ b/features/vehicles.feature
@@ -28,8 +28,6 @@ Feature: Vehicles
       And I press the Continue
     Then I should be on the exempt page
     When I press the Continue to add vehicle
-    Then I should be on the local vehicles exemptions page
-    When I press "Continue" button
     Then I should be on the manage vehicles page
 
   Scenario: Adding the not found vehicle

--- a/spec/requests/vehicles/confirm_and_add_exempt_vehicle_to_fleet_spec.rb
+++ b/spec/requests/vehicles/confirm_and_add_exempt_vehicle_to_fleet_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', type: :request do
-  subject(:http_request) do
+  subject do
     post confirm_and_add_exempt_vehicle_to_fleet_vehicles_path,
          params: { 'confirm-vehicle' => confirmation }
   end
@@ -13,7 +13,7 @@ describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', ty
   let(:user) { create_user(account_id: account_id) }
 
   it 'returns redirect to the login page' do
-    http_request
+    subject
     expect(response).to redirect_to(new_user_session_path)
   end
 
@@ -22,7 +22,7 @@ describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', ty
 
     context 'without VRN in the session' do
       it 'returns redirect to vehicles#enter_details' do
-        http_request
+        subject
         expect(response).to redirect_to(enter_details_vehicles_path)
       end
     end
@@ -37,7 +37,7 @@ describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', ty
         let(:confirmation) { 'no' }
 
         it 'redirects to incorrect details page' do
-          http_request
+          subject
           expect(response).to redirect_to(incorrect_details_vehicles_path)
         end
       end
@@ -46,7 +46,7 @@ describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', ty
         let(:confirmation) { '' }
 
         it 'redirects to confirm details page' do
-          http_request
+          subject
           expect(response).to redirect_to(details_vehicles_path)
         end
       end
@@ -56,31 +56,27 @@ describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', ty
           before do
             allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_return(true)
             add_to_session(vrn: @vrn)
+            subject
           end
 
           it 'adds the vehicle to the fleet' do
-            expect(FleetsApi).to receive(:add_vehicle_to_fleet)
+            expect(FleetsApi).to have_received(:add_vehicle_to_fleet)
               .with(vrn: @vrn, account_id: account_id)
-            subject
           end
 
           it 'removes vrn from session' do
-            subject
             expect(session[:vrn]).to be_nil
           end
 
           it 'removes show_continue_button from session' do
-            subject
             expect(session[:show_continue_button]).to be_nil
           end
 
           it 'sets :success flash message' do
-            subject
             expect(flash[:success]).to eq("You have successfully added #{@vrn} to your vehicle list.")
           end
 
           it 'redirects to local vehicle exemptions' do
-            http_request
             expect(response).to redirect_to(fleets_path)
           end
         end

--- a/spec/requests/vehicles/confirm_and_add_exempt_vehicle_to_fleet_spec.rb
+++ b/spec/requests/vehicles/confirm_and_add_exempt_vehicle_to_fleet_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'VehicleController - POST #confirm_and_add_exempt_vehicle_to_fleet', type: :request do
+  subject(:http_request) do
+    post confirm_and_add_exempt_vehicle_to_fleet_vehicles_path,
+         params: { 'confirm-vehicle' => confirmation }
+  end
+
+  let(:confirmation) { 'yes' }
+  let(:account_id) { SecureRandom.uuid }
+  let(:user) { create_user(account_id: account_id) }
+
+  it 'returns redirect to the login page' do
+    http_request
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  context 'when user is signed in' do
+    before { sign_in user }
+
+    context 'without VRN in the session' do
+      it 'returns redirect to vehicles#enter_details' do
+        http_request
+        expect(response).to redirect_to(enter_details_vehicles_path)
+      end
+    end
+
+    context 'with VRN in the session' do
+      before do
+        allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_return(true)
+        add_to_session(vrn: @vrn)
+      end
+
+      context 'when user does not confirm details' do
+        let(:confirmation) { 'no' }
+
+        it 'redirects to incorrect details page' do
+          http_request
+          expect(response).to redirect_to(incorrect_details_vehicles_path)
+        end
+      end
+
+      context 'when confirmation is empty' do
+        let(:confirmation) { '' }
+
+        it 'redirects to confirm details page' do
+          http_request
+          expect(response).to redirect_to(details_vehicles_path)
+        end
+      end
+
+      context 'when user confirms details' do
+        context 'without VRN previously added' do
+          before do
+            allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_return(true)
+            add_to_session(vrn: @vrn)
+          end
+
+          it 'adds the vehicle to the fleet' do
+            expect(FleetsApi).to receive(:add_vehicle_to_fleet)
+              .with(vrn: @vrn, account_id: account_id)
+            subject
+          end
+
+          it 'removes vrn from session' do
+            subject
+            expect(session[:vrn]).to be_nil
+          end
+
+          it 'removes show_continue_button from session' do
+            subject
+            expect(session[:show_continue_button]).to be_nil
+          end
+
+          it 'sets :success flash message' do
+            subject
+            expect(flash[:success]).to eq("You have successfully added #{@vrn} to your vehicle list.")
+          end
+
+          it 'redirects to local vehicle exemptions' do
+            http_request
+            expect(response).to redirect_to(fleets_path)
+          end
+        end
+
+        context 'with VRN previously added' do
+          let(:message) { 'AccountVehicle already exists' }
+
+          before do
+            allow(FleetsApi).to receive(:add_vehicle_to_fleet).and_raise(
+              BaseApi::Error422Exception.new(422, '', message: message)
+            )
+            add_to_session(vrn: @vrn)
+            user.add_vehicle(@vrn)
+            subject
+          end
+
+          it 'removes vrn from session' do
+            expect(session[:vrn]).to be_nil
+          end
+
+          it 'removes show_continue_button from session' do
+            expect(session[:show_continue_button]).to be_nil
+          end
+
+          it 'sets :warning flash message' do
+            expect(flash[:warning]).to eq("#{@vrn} already exists in your vehicle list.")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2867

## Description
<!--- Describe your changes in detail -->
* When a vehicle is marked as exempted one, we should not show local exemption page, we should continue the process which means we just need to perform request to add such vehicle.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Add exempted VRN to fleet
* You should see global exemption page
* After clicking `Continue` vehicle should be added (without showing local exemption page).

## Screenshots (if appropriate):
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
