### PR TITLE
[CAZ-2402] Fix errors ordeing in error summary

### DIFF
--- a/app/forms/add_new_user_form.rb
+++ b/app/forms/add_new_user_form.rb
@@ -6,14 +6,17 @@ class AddNewUserForm < NewUserBaseForm
   # validates name attribute to presence
   validates :name, presence: { message: I18n.t('add_new_user_form.errors.name_missing') }
 
+  # validates email attribute to presence
+  validates :email, presence: { message: I18n.t('add_new_user_form.errors.email_missing') }
+
   # validates email format
   validates :email, format: {
     with: EMAIL_FORMAT,
     message: I18n.t('input_form.errors.invalid_format')
   }, allow_blank: true
 
-  # validates email attribute to presence
-  validates :email, presence: { message: I18n.t('add_new_user_form.errors.email_missing') }
+  # validates +email+ against duplication
+  validate :email_not_duplicated, if: -> { email.present? }
 
   ##
   # Initializes the form

--- a/app/forms/add_new_user_permissions_form.rb
+++ b/app/forms/add_new_user_permissions_form.rb
@@ -3,6 +3,9 @@
 ##
 # This class is used to validate user data filled in +app/views/users/new.html.haml+.
 class AddNewUserPermissionsForm < NewUserBaseForm
+  # validates +email+ against duplication
+  validate :email_not_duplicated, if: -> { email.present? }
+
   # validates name attribute to presence
   validates :permissions, presence: { message: I18n.t('add_new_user_form.errors.permissions_missing') }
 

--- a/app/forms/new_user_base_form.rb
+++ b/app/forms/new_user_base_form.rb
@@ -4,9 +4,6 @@
 # This class is used to validate user data filled in
 # +app/views/users/new.html.haml+ and +app/views/users/add_permissions.html.haml+.
 class NewUserBaseForm < BaseForm
-  # validates +email+ against duplication
-  validate :email_not_duplicated, if: -> { email.present? }
-
   private
 
   attr_reader :account_id, :name, :email

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,6 +1,6 @@
 - title_and_header = 'Add a user'
 - content_for(:title, title_and_header)
-- errors = flash[:errors]
+- errors = flash[:errors]&.symbolize_keys
 
 = link_to 'Back', @return_url, class: 'govuk-back-link'
 
@@ -8,7 +8,21 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       - if errors.present?
-        = render 'common/errors_summary', errors: errors
+        .govuk-error-summary{'aria-labelledby': 'error-summary-title',
+                             'data-module': 'govuk-error-summary',
+                             role: 'alert',
+                             tabindex: '-1'}
+          %h2#error-summary-title.govuk-error-summary__title
+            There is a problem
+          .govuk-error-summary__body
+            %ul.govuk-list.govuk-error-summary__list
+              %li
+                - if errors[:name].present?
+                  %li.custom-csv-error
+                    = link_to(errors[:name].first, "#name-error", id: "name-error-summary")
+                - if errors[:email].present?
+                  %li.custom-csv-error
+                    = link_to(errors[:email].first, "#email-error", id: "email-error-summary")
 
       = form_for('new_user', url: users_path, method: :post) do |f|
         .govuk-form-group{class: ('govuk-form-group--error' if errors.present?)}

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,6 +1,6 @@
 - title_and_header = 'Add a user'
 - content_for(:title, title_and_header)
-- errors = flash[:errors]&.symbolize_keys
+- errors = flash[:errors]
 
 = link_to 'Back', @return_url, class: 'govuk-back-link'
 
@@ -8,21 +8,7 @@
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       - if errors.present?
-        .govuk-error-summary{'aria-labelledby': 'error-summary-title',
-                             'data-module': 'govuk-error-summary',
-                             role: 'alert',
-                             tabindex: '-1'}
-          %h2#error-summary-title.govuk-error-summary__title
-            There is a problem
-          .govuk-error-summary__body
-            %ul.govuk-list.govuk-error-summary__list
-              %li
-                - if errors[:name].present?
-                  %li.custom-csv-error
-                    = link_to(errors[:name].first, "#name-error", id: "name-error-summary")
-                - if errors[:email].present?
-                  %li.custom-csv-error
-                    = link_to(errors[:email].first, "#email-error", id: "email-error-summary")
+        = render 'common/errors_summary', errors: errors
 
       = form_for('new_user', url: users_path, method: :post) do |f|
         .govuk-form-group{class: ('govuk-form-group--error' if errors.present?)}


### PR DESCRIPTION
## Motivation and Context
https://eaflood.atlassian.net/browse/CAZ-2402?focusedCommentId=224469

## Description
Hardcode ordering of the errors in summary to reflect order of the form input

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
![Screenshot_20200707_155224](https://user-images.githubusercontent.com/1614426/86791640-0a4b6100-c06a-11ea-830c-cb79558da97d.png)

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
