### PR TITLE
[CAZB-2208] Display "Came into operation" copy on D-Day + 6

### DIFF
--- a/app/services/payment_dates.rb
+++ b/app/services/payment_dates.rb
@@ -28,7 +28,7 @@ class PaymentDates < BaseService
 
   # Checks if D-Day notice should be shown
   def d_day_notice
-    charge_start_date.between?(Time.zone.today - 5.days, Time.zone.today)
+    charge_start_date.between?(Time.zone.today - 6.days, Time.zone.today)
   end
 
   private

--- a/spec/services/payment_dates_spec.rb
+++ b/spec/services/payment_dates_spec.rb
@@ -114,7 +114,7 @@ describe PaymentDates do
       end
 
       context 'when #charge_start_date is not considered' do
-        let(:charge_start_date) { Time.zone.today - 6.days }
+        let(:charge_start_date) { Time.zone.today - 7.days }
 
         it 'returns false' do
           expect(service.d_day_notice).to be_falsey


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2208

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Screenshot from 8 July (D-Day as 2 July):
![image](https://user-images.githubusercontent.com/5519481/86953609-f2044080-c154-11ea-986c-e1329d7c4389.png)

Screenshot from 8 July (D-Day as 1 July):
![image](https://user-images.githubusercontent.com/5519481/86953623-f597c780-c154-11ea-93e0-4c606d01def2.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
