### PR TITLE
[CAZ-2342] Update back links behaviour during the timeout process

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@
 #
 class SessionsController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :assign_back_button_url, only: :logout_notice
+  skip_before_action :verify_authenticity_token, only: :timeout_return_page
 
   ##
   # Renders the sign out page
@@ -19,6 +19,18 @@ class SessionsController < ApplicationController
   end
 
   ##
+  # Stores page to which user should be taken back after clicking `Continue` on the logout notice page.
+  #
+  # ==== Path
+  #
+  #     :POST /timeout_return_page
+  #
+  def timeout_return_page
+    session[:timeout_return_page] = params[:timeout_return_path]
+    head :no_content
+  end
+
+  ##
   # Renders the logout notice page
   #
   # ==== Path
@@ -26,7 +38,7 @@ class SessionsController < ApplicationController
   #    :GET /logout_notice
   #
   def logout_notice
-    @back_button_url = request.referer
+    @back_button_url = session[:timeout_return_page]
     render 'devise/sessions/logout_notice'
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@
 #
 class SessionsController < ApplicationController
   skip_before_action :authenticate_user!
-  skip_before_action :verify_authenticity_token, only: :timeout_return_page
+  skip_before_action :verify_authenticity_token, only: :assign_logout_notice_back_url
 
   ##
   # Renders the sign out page
@@ -23,10 +23,10 @@ class SessionsController < ApplicationController
   #
   # ==== Path
   #
-  #     :POST /timeout_return_page
+  #     :POST /assign_logout_notice_back_url
   #
-  def timeout_return_page
-    session[:timeout_return_page] = params[:timeout_return_path]
+  def assign_logout_notice_back_url
+    session[:logout_notice_back_url] = params[:logout_notice_back_url]
     head :no_content
   end
 
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
   #    :GET /logout_notice
   #
   def logout_notice
-    @back_button_url = session[:timeout_return_page]
+    @back_button_url = session[:logout_notice_back_url]
     render 'devise/sessions/logout_notice'
   end
 

--- a/app/javascript/packs/redirect_to_timeout_notice.js
+++ b/app/javascript/packs/redirect_to_timeout_notice.js
@@ -7,11 +7,11 @@ const timeOffset = 1000 * 60 * redirectTimeInMinutes;
 
 setTimeout(function(path) {
   const xmlhttp = new XMLHttpRequest();
-  const payload = JSON.stringify({ "timeout_return_path": window.location.href });
+  const payload = JSON.stringify({ "logout_notice_back_url": window.location.href });
 
   // Request sends the current url to be stored in session. When user will click 'continue'
   // on the logout_notice_path, he will be taken back to the URL provided here.
-  xmlhttp.open('POST', '/timeout_return_page');
+  xmlhttp.open('POST', '/assign_logout_notice_back_url');
   xmlhttp.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
   xmlhttp.send(payload);
 

--- a/app/javascript/packs/redirect_to_timeout_notice.js
+++ b/app/javascript/packs/redirect_to_timeout_notice.js
@@ -6,5 +6,20 @@ const redirectTimeInMinutes = timeoutTimeInMinutes - 1;
 const timeOffset = 1000 * 60 * redirectTimeInMinutes;
 
 setTimeout(function(path) {
-  window.location.replace(path);
+  const xmlhttp = new XMLHttpRequest();
+  const payload = JSON.stringify({ "timeout_return_path": window.location.href });
+
+  // Request sends the current url to be stored in session. When user will click 'continue'
+  // on the logout_notice_path, he will be taken back to the URL provided here.
+  xmlhttp.open('POST', '/timeout_return_page');
+  xmlhttp.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+  xmlhttp.send(payload);
+
+  xmlhttp.onreadystatechange = function() {
+    // When request is successful, user is redirected to the logout_notice_path.
+    if (xmlhttp.readyState == 4 && xmlhttp.status == 204) {
+      window.location.replace(path);
+    }
+  }
+
 }, timeOffset, logoutNoticePath);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   scope controller: 'sessions' do
     get 'sign-out', to: 'sessions#sign_out_page'
-    post 'timeout_return_page'
+    post 'assign_logout_notice_back_url'
     get 'logout_notice'
     get 'timedout-user'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   scope controller: 'sessions' do
     get 'sign-out', to: 'sessions#sign_out_page'
+    post 'timeout_return_page'
     get 'logout_notice'
     get 'timedout-user'
   end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZ-2342

## Description
<!--- Describe your changes in detail -->
* When a user is taken to the `logout_notice_page`, we perform POST request which stores the previous page in the session. Later this value is used to redirect the user back to where he was before the timeout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Log in
* Do not perform any action for 14 minutes
* You are redirected to the logout_notice_page.
* Click `Cookies` link on the page footer.
* Click `Back`
* Click `Continue`
* You should be redirected to the page on which you were before the timeout (and not to Cookies page).

## Screenshots (if appropriate):
N/A
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
