### PR TITLE
[CAZB-2144] Redirect to the edit user page when was chosen `No`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ config/ssl/
 .vagrant
 /sonar-scanner*
 
-# Ignore RDoc HTML files
+# RDoc HTML files
 /doc/app
+
+# Redis files
+*.rdb

--- a/app/controllers/users_management/remove_users_controller.rb
+++ b/app/controllers/users_management/remove_users_controller.rb
@@ -47,8 +47,10 @@ module UsersManagement
       if confirmation == 'yes'
         AccountsApi.delete_user(account_id: current_user.account_id, account_user_id: account_user_id)
         flash[:success] = I18n.t('user_removed', full_user_name: full_user_name)
+        redirect_to users_path
+      else
+        redirect_to edit_user_path(account_user_id)
       end
-      redirect_to users_path
     end
 
     # user remove confirmation, e.g 'yes'

--- a/features/users_management/remove_user.feature
+++ b/features/users_management/remove_user.feature
@@ -29,6 +29,5 @@ Feature: Manage user
       And I should be on the Delete user page
       And I choose 'No'
     Then I press the Continue
-      And I should be on the Manage users page
-      And I should not see 'You have successfully removed John Doe from your account.'
+      And I should be on the Manage user page
 

--- a/spec/requests/users_management/remove_users/confirm_remove_spec.rb
+++ b/spec/requests/users_management/remove_users/confirm_remove_spec.rb
@@ -34,8 +34,8 @@ describe 'UsersManagement::RemoveUsersController - POST #confirm_remove' do
         context 'when confirmation is no' do
           let(:confirmation) { 'no' }
 
-          it 'redirects to the users page' do
-            expect(subject).to redirect_to(users_path)
+          it 'redirects to the edit user page' do
+            expect(subject).to redirect_to(edit_user_path(@uuid))
           end
         end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2144?focusedCommentId=228889
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
