### PR TITLE
[CAZB-2166] Fix back button on company and user history pages

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -45,7 +45,5 @@ class DashboardController < ApplicationController
     session[:new_payment] = nil
     session[:company_back_link_history] = nil
     session[:user_back_link_history] = nil
-    session[:company_payment_history] = nil
-    session[:payment_details_back_link] = nil
   end
 end

--- a/app/controllers/payment_history/payment_history_controller.rb
+++ b/app/controllers/payment_history/payment_history_controller.rb
@@ -95,16 +95,15 @@ module PaymentHistory
     end
 
     # Returns back link url on the payment history details page
-    # Assigns +@company_payment_history+ to true if last visited page was the company payment history
     # Assign +payment_details_back_link+ and +company_payment_history+ to the session
-    def determinate_back_link
-      if session[:payment_details_back_link]
-        session[:payment_details_back_link]
-      elsif request.referer&.include?(company_payment_history_path)
+    def determinate_back_link # rubocop:disable Metrics/AbcSize
+      if request.referer&.include?(company_payment_history_path)
         session[:company_payment_history] = true
-        session[:payment_details_back_link] = company_payment_history_path
+        session[:payment_details_back_link] = request.referer
+      elsif request.referer&.include?(user_payment_history_path)
+        session[:payment_details_back_link] = request.referer
       else
-        session[:payment_details_back_link] = user_payment_history_path
+        session[:payment_details_back_link] || user_payment_history_path
       end
     end
   end

--- a/app/services/back_link_history_service.rb
+++ b/app/services/back_link_history_service.rb
@@ -28,7 +28,6 @@ class BackLinkHistoryService < BaseService
   #
   # Returns a back link url
   def call
-    log_action('Saving page number to the history session')
     update_steps_history
     clear_more_then_10_steps
     determinate_back_link_url
@@ -39,16 +38,19 @@ class BackLinkHistoryService < BaseService
   # Creating first step or adding page number to correct step or dont do anything in case if page was refreshed
   def update_steps_history # rubocop:disable Metrics/AbcSize
     if history.nil?
+      log_action('Creating first step into the back link history')
       session[session_key] = { '1' => page }
-    elsif back_button && history
-      clear_unused_steps
     elsif last_step_page != page
+      return clear_unused_steps if back_button && history
+
+      log_action('Adding step to the back link history')
       session.dig(session_key)[next_step] = page
     end
   end
 
   # Removes futures steps when back button was used
   def clear_unused_steps
+    log_action('Clearing future steps from the back link history')
     current_step_keys = history.select { |k, _v| k <= previous_step }.keys
     session[session_key] = history.slice(*current_step_keys)
   end

--- a/features/payment_history.feature
+++ b/features/payment_history.feature
@@ -77,6 +77,8 @@ Feature: Payment History
 
   Scenario: User sees payment details history from Company payments history page
     Given I want visit the Payments details page from Company payments history page
+      And I press 3 pagination button on the payment history page
+      And I should be on the Company payment history page number 3
     Then I press 'View details' link
       And I should be on the the Payment details history page
     Then I press 'Cookies' link
@@ -86,14 +88,23 @@ Feature: Payment History
       And I should see 'Payment made by'
       And I should see 'Print this page'
     Then I press 'Back' link
-      And I should be on the the Company payment history page
+      And I should be on the Company payment history page number 3
+    Then I press 2 pagination button on the payment history page
+      And I should be on the Company payment history page number 2
+    Then I press 'Back' link
+      And I should be on the Company payment history page number 3 when using back button
+      And I refresh current page
+    Then I press 'Back' link
+      And I should be on the Company payment history page number 1 when using back button
     Then I press 'View details' link
       And I should be on the the Payment details history page
     Then I press 'Return to payment history' link
-      And I should be on the the Company payment history page
+      And I should be on the Company payment history page number 1 when using back button
 
   Scenario: User sees payment details history from User payments history page
     Given I want visit the Payments details page from User payments history page
+      And I press 3 pagination button on the payment history page
+      And I should be on the User payment history page number 3
     Then I press 'View details' link
       And I should be on the the Payment details history page
     Then I press 'Cookies' link
@@ -102,8 +113,15 @@ Feature: Payment History
       And I should be on the the Payment details history page
       And I should not see 'Print this page'
     Then I press 'Back' link
-      And I should be on the the User payment history page
+      And I should be on the User payment history page number 3
+    Then I press 2 pagination button on the payment history page
+      And I should be on the User payment history page number 2
+    Then I press 'Back' link
+      And I should be on the User payment history page number 3 when using back button
+      And I refresh current page
+    Then I press 'Back' link
+      And I should be on the User payment history page number 1 when using back button
     Then I press 'View details' link
       And I should be on the the Payment details history page
     Then I press 'Return to payment history' link
-      And I should be on the the User payment history page
+      And I should be on the User payment history page number 1 when using back button

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -82,6 +82,10 @@ And('I uncheck {string}') do |string|
   uncheck(string)
 end
 
+Then('I refresh current page') do
+  visit current_url
+end
+
 def mock_api_responses
   mock_vehicles_in_fleet
   mock_debits

--- a/spec/services/back_link_history_service_spec.rb
+++ b/spec/services/back_link_history_service_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe BackLinkHistoryService do
       end
     end
 
+    context 'when session is not empty, back button is true and last page the same with new one' do
+      let(:session) { { company_back_link_history: { '1' => 1, '2' => 4 } } }
+      let(:page) { 4 }
+      let(:back_button) { true }
+
+      it 'returns correct page' do
+        expect(subject).to include('page=1?back=true')
+      end
+
+      it 'not adding steps to the session' do
+        subject
+        expect(session[:company_back_link_history]).to eq({ '1' => 1, '2' => 4 })
+      end
+    end
+
     context 'when session is not empty and back button is true' do
       let(:session) { { company_back_link_history: { '1' => 1, '2' => 4 } } }
       let(:back_button) { true }


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2166
## Description
<!--- Describe your changes in detail -->
1. Fixed bug when user refreshing page with url params `back=true`, we should not clear steps
2. Back button should redirect to previous url not path with page number in params
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
