### PR TITLE
[CAZB-2580] Display CAZ charge status on manage vehicle page

### DIFF
--- a/app/models/clean_air_zone.rb
+++ b/app/models/clean_air_zone.rb
@@ -42,6 +42,11 @@ class CleanAirZone
     Date.parse(caz_data[:active_charge_start_date])
   end
 
+  # Check if clean air zone charge is live, eg. 'true'
+  def live?
+    !active_charge_start_date.future?
+  end
+
   # Checks if zones was already checked by user before.
   # Returns a boolean.
   def checked?(checked_zones)

--- a/app/views/payments/payments/failure.html.haml
+++ b/app/views/payments/payments/failure.html.haml
@@ -17,8 +17,8 @@
       %p
         The charge for your journey is not paid. You may receive a penalty charge notice (PCN) if payment is not made within 7 days from driving in the zone.
       %p
-        If you would like to try the payment again 
-        = succeed '.' do 
+        If you would like to try the payment again
+        = succeed '.' do
           = link_to 'return to Your account', root_path
       = render 'shared/print_link'
       %p

--- a/app/views/vehicles_management/fleets/index.html.haml
+++ b/app/views/vehicles_management/fleets/index.html.haml
@@ -28,7 +28,7 @@
                            'https://www.gov.uk/change-vehicle-details-registration-certificate/how-to-tell-dvla',
                            id: 'update_record_link')
         to make sure it holds the correct information for you. The charge may still need to be paid for an individual vehicle.
-        You can 
+        You can
         = external_link_to('pay a charge for a single vehicle',
                            single_vehicle_payment_link,
                            class: 'govuk-link',
@@ -43,6 +43,8 @@
             - @zones.each do |zone|
               %th.govuk-table__header{scope: 'col', class: 'vehicle-management-column'}
                 = zone.name
+                %br
+                = zone.live? ? '(Live)' : '(Upcoming)'
             %th.govuk-table__header{scope: 'col'}
               .govuk-visually-hidden Actions
         %tbody.govuk-table__body
@@ -58,6 +60,13 @@
               %td.govuk-table__cell{scope: 'row'}
                 = link_to('Remove', assign_delete_fleets_path(vrn: vehicle.vrn))
       = render 'pagination'
+      .govuk-inset-text
+        %b Live
+        \- you must pay a charge to drive in the zone
+        %br
+        %b Upcoming
+        \- charging will be starting soon. You can see the live dates are on the
+        = link_to('guidance page', 'https://www.gov.uk/guidance/driving-in-a-clean-air-zone#cleanairzones')
 
       - if @pagination.total_vehicles_count >= 2
         %p

--- a/features/step_definitions/vehicles_management/fleets_steps.rb
+++ b/features/step_definitions/vehicles_management/fleets_steps.rb
@@ -29,6 +29,10 @@ Then('I should be on the submission method page') do
   expect(page).to have_current_path(submission_method_fleets_path)
 end
 
+Then('I should be able to check CAZ charging statuses') do
+  expect(page).to have_current_path(submission_method_fleets_path)
+end
+
 When('I select manual entry') do
   choose('Individual')
 end

--- a/features/vehicles_management/fleets.feature
+++ b/features/vehicles_management/fleets.feature
@@ -10,6 +10,12 @@ Feature: Fleets
       And I press the Continue
     Then I should be on the upload page
 
+  Scenario: Visiting the manage fleet page with not empty fleet
+    When I have vehicles in my fleet
+      And I visit the manage vehicles page
+    Then I should see 'Live' 3 times
+    Then I should see 'Upcoming' 1 times
+
   Scenario: No selection on the submission method page
     When I visit the submission method page
       And I press the Continue

--- a/spec/models/clean_air_zones_spec.rb
+++ b/spec/models/clean_air_zones_spec.rb
@@ -49,6 +49,28 @@ describe CleanAirZone, type: :model do
     end
   end
 
+  describe '.live?' do
+    it 'returns true' do
+      expect(subject.live?).to eq(true)
+    end
+
+    context 'when active_charge_start_date is today' do
+      let(:active_charge_start_date) { Time.zone.today.to_s }
+
+      it 'returns true' do
+        expect(subject.live?).to eq(true)
+      end
+    end
+
+    context 'when active_charge_start_date is in the future' do
+      let(:active_charge_start_date) { Date.tomorrow.to_s }
+
+      it 'returns false' do
+        expect(subject.live?).to eq(false)
+      end
+    end
+  end
+
   describe '.checked?' do
     it 'returns true' do
       expect(subject.checked?([id])).to eq(true)


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Card: https://eaflood.atlassian.net/browse/CAZB-2580

## Description
<!--- Describe your changes in detail -->
Added CAZ status with info to Manage my vehicles page. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![image](https://user-images.githubusercontent.com/998642/89777227-95a58f80-db0b-11ea-9878-e5817c438c11.png)

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
