### PR TITLE
[CAZB-3115] Prevent password reuse on Reset Password flow

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -170,8 +170,8 @@ class PasswordsController < ApplicationController
   rescue BaseApi::Error400Exception
     session[:reset_password_token] = nil
     redirect_to invalid_passwords_path
-  rescue BaseApi::Error422Exception
-    rerender_index({ password: [I18n.t('new_password_form.errors.password_complexity')] })
+  rescue BaseApi::Error422Exception => e
+    rerender_index({ password: parse_422_error(e.body['errorCode']) })
   end
 
   # Renders :index with assigned errors and token
@@ -203,5 +203,15 @@ class PasswordsController < ApplicationController
   def redirect_to_dashboard
     session[:password_updated] = true
     redirect_to dashboard_path
+  end
+
+  # Returns correct error message for 422 error
+  def parse_422_error(code)
+    case code
+    when 'passwordNotValid'
+      [I18n.t('new_password_form.errors.password_complexity')]
+    when 'newPasswordReuse'
+      [I18n.t('update_password_form.errors.password_reused')]
+    end
   end
 end

--- a/features/passwords/password_reset.feature
+++ b/features/passwords/password_reset.feature
@@ -28,9 +28,11 @@ Feature: Password reset
     When I enter valid password and confirmation
     Then I should be on the success page
 
-  Scenario: Not enough complex password
+  Scenario: Not enough complex or reused password
     Given I visit passwords
     When I enter too easy password and confirmation
     Then I should see "12 characters long, include at least one upper case letter, a number, and a special character" 2 times
+    When I try to reuse old password
+    Then I should see "You have already used that password, choose a new one" 2 times
     When I enter valid password and confirmation
     Then I should be on the success page

--- a/features/step_definitions/password_reset_steps.rb
+++ b/features/step_definitions/password_reset_steps.rb
@@ -48,13 +48,11 @@ When('I enter not matching password and confirmation') do
 end
 
 When('I enter valid password and confirmation') do
-  password = 'password'
-  fill_in('passwords[password]', with: password)
-  fill_in('passwords[password_confirmation]', with: password)
+  fill_in_passwords
   token = find('#token', visible: false).value
   allow(AccountsApi)
     .to receive(:set_password)
-    .with(token: token, password: password)
+    .with(token: token, password: 'password')
     .and_return(true)
   click_button 'Update password'
 end
@@ -64,11 +62,22 @@ Then('I should be on the success page') do
 end
 
 When('I enter too easy password and confirmation') do
-  password = 'password'
-  fill_in('passwords[password]', with: password)
-  fill_in('passwords[password_confirmation]', with: password)
+  fill_in_passwords
   allow(AccountsApi)
     .to receive(:set_password)
-    .and_raise(BaseApi::Error422Exception.new(422, '', {}))
+    .and_raise(BaseApi::Error422Exception.new(422, '', 'errorCode' => 'passwordNotValid'))
   click_button 'Update password'
+end
+
+When('I try to reuse old password') do
+  fill_in_passwords
+  allow(AccountsApi)
+    .to receive(:set_password)
+    .and_raise(BaseApi::Error422Exception.new(422, '', 'errorCode' => 'newPasswordReuse'))
+  click_button 'Update password'
+end
+
+def fill_in_passwords
+  fill_in('passwords[password]', with: 'password')
+  fill_in('passwords[password_confirmation]', with: 'password')
 end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3115

## Description
<!--- Describe your changes in detail -->
Improved error handling to handle different 422 errors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cucumber, rspec
## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
