### PR TITLE
[CAZB-3185] Payment Lock back link fix

### DIFF
--- a/app/views/payments/payments/in_progress.html.haml
+++ b/app/views/payments/payments/in_progress.html.haml
@@ -9,7 +9,7 @@
       %h1.govuk-heading-l
         = title_and_header
       %p
-        = "#{@user_locking_email} is paying charges for #{@zone.name} Clean Air Zone."
+        = "#{@user_locking_email} is paying charges for #{@zone&.name} Clean Air Zone."
       %p
         To avoid the possibility of you both paying the same charge, you need to wait till they have finished 
         before making your payment.

--- a/spec/requests/payments/payments/in_progress_spec.rb
+++ b/spec/requests/payments/payments/in_progress_spec.rb
@@ -6,18 +6,38 @@ describe 'PaymentsController - GET #in_progress' do
   subject { get in_progress_payments_path }
 
   let(:caz_id) { @uuid }
-  let(:user) { make_payments_user }
+  let(:account_id) { SecureRandom.uuid }
+  let(:user) { create_user(account_id: account_id, user_id: SecureRandom.uuid, email: 'test1@test.com') }
+  let(:another_user) do
+    create_user(account_id: account_id, user_id: SecureRandom.uuid, email: 'test2@test.com')
+  end
 
   context 'correct permissions' do
     let(:fleet) { create_chargeable_vehicles }
 
-    before do
-      add_caz_lock_to_redis(user)
-      sign_in user
+    before { sign_in user }
+
+    context 'with la in the session and with no CAZ lock' do
+      before do
+        add_caz_lock_to_redis(user)
+        mock_clean_air_zones
+        mock_fleet(fleet)
+        add_to_session(new_payment: { caz_id: caz_id })
+      end
+
+      it 'returns a 302 FOUND status' do
+        subject
+        expect(response).to have_http_status(:found)
+      end
+
+      it 'redirects to selected CAZ payment matrix' do
+        expect(subject).to redirect_to(matrix_payments_path)
+      end
     end
 
-    context 'with la in the session' do
+    context 'with la in the session and CAZ locked by other user' do
       before do
+        add_caz_lock_to_redis(another_user)
         mock_clean_air_zones
         mock_fleet(fleet)
         add_to_session(new_payment: { caz_id: caz_id })

--- a/spec/requests/payments/payments/in_progress_spec.rb
+++ b/spec/requests/payments/payments/in_progress_spec.rb
@@ -8,9 +8,7 @@ describe 'PaymentsController - GET #in_progress' do
   let(:caz_id) { @uuid }
   let(:account_id) { SecureRandom.uuid }
   let(:user) { create_user(account_id: account_id, user_id: SecureRandom.uuid) }
-  let(:another_user) do
-    create_user(account_id: account_id, user_id: SecureRandom.uuid)
-  end
+  let(:another_user) { create_user(account_id: account_id, user_id: SecureRandom.uuid) }
 
   context 'correct permissions' do
     let(:fleet) { create_chargeable_vehicles }

--- a/spec/support/chargeable_vehicles_factory.rb
+++ b/spec/support/chargeable_vehicles_factory.rb
@@ -2,7 +2,7 @@
 
 module ChargeableVehiclesFactory
   def create_chargeable_vehicles(vehicles = mocked_chargeable_vehicles)
-    instance_double(VehiclesManagement::Fleet, charges: vehicles)
+    instance_double(VehiclesManagement::Fleet, charges: vehicles, any_chargeable_vehicles_in_caz?: true)
   end
 
   private


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3185

## Description
<!--- Describe your changes in detail -->
1. CAZ lock will be now released also on `payments_path`
2. Checking if CAZ is locked on `in_progress_payments_path`. If user refreshes the page and the CAZ lock is released, user is redirected to `matrix_payments_path`
3. User is no longer able to bypass CAZ lock by directly entering `/payments/matrix` url

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, rspec added

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
