### PR TITLE
Add error logging when unable to connect to Redis

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,15 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable redis cache store for session
-  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] } if ENV['REDIS_URL']
+  if ENV['REDIS_URL']
+    config.cache_store = :redis_cache_store, {
+      url: ENV['REDIS_URL'],
+      error_handler: lambda do |response|
+        # Report errors to Sentry as warnings
+        Rails.logger.error "Unable to connect to Redis - #{response}"
+      end
+    }
+  end
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,15 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Use a different cache store in production - cluster of redis instances.
-  config.cache_store = :redis_cache_store, { cluster: [ENV['REDIS_URL']] } if ENV['REDIS_URL']
+  if ENV['REDIS_URL']
+    config.cache_store = :redis_cache_store, {
+      url: ENV['REDIS_URL'],
+      error_handler: lambda do |response|
+        # Report errors to Sentry as warnings
+        Rails.logger.error "Unable to connect to Redis - #{response}"
+      end
+    }
+  end
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
When testing application on AWS sometimes users are experiencing strange redirects to homepage,
or are being asked to provide valid login details more than once in a row in order to be logged in.
Under closer inspection it has been revealed that there is a mismatch between CSRF token that is
sent by a user, and the one Rails have saved in session.

Potential mismatch may be caused by connectivity errors with Redis server. Since Rails fails silently
unsuccessful calls to `cache_store` we have needed to add explicit error statement to logs.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
A rails error logger has been added to unsuccessful cache store operations.
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1729299/94466105-3128b780-01c1-11eb-902c-a1fe21b99fc5.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
