### PR TITLE
Change Redis config to be clustered in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   # Use a different cache store in production - cluster of redis instances.
   if ENV['REDIS_URL']
     config.cache_store = :redis_cache_store, {
-      url: ENV['REDIS_URL'],
+      cluster: [ENV['REDIS_URL']],
       error_handler: lambda do |response|
         # Report errors to Sentry as warnings
         Rails.logger.error "Unable to connect to Redis - #{response}"


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
Due to my mistake in https://github.com/InformedSolutions/JAQU-CAZ-Fleets-UI/pull/604 a Redis is no longer clustered in production resulting higher error rate when things are moved across shards preventing users to log in.

## Description
This changes Redis config to be clustered on production
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
