### PR TITLE
CAZB-3063 Regex for email changed

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -7,7 +7,7 @@ class BaseForm
   include ActiveModel::Validations
 
   # Email Address Regular Expression
-  EMAIL_FORMAT = /\A(?:(?:[\w\d\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~])+(?:\.{1})?)+(?:[\w\d\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~])+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/.freeze
+  EMAIL_FORMAT = /\A(([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)(\.{1}))*([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/.freeze
 
   # Overrides default initializer for compliance with form_for method in content_form view
   def initialize(attributes = {})

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -7,7 +7,7 @@ class BaseForm
   include ActiveModel::Validations
 
   # Email Address Regular Expression
-  EMAIL_FORMAT = URI::MailTo::EMAIL_REGEXP.freeze
+  EMAIL_FORMAT = /\A(?:(?:[\w\d\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~])+(?:\.{1})?)+(?:[\w\d\!\#\$\%\&\'\*\+\-\/\=\?\^\_\`\{\|\}\~])+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/.freeze
 
   # Overrides default initializer for compliance with form_for method in content_form view
   def initialize(attributes = {})

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -7,7 +7,7 @@ class BaseForm
   include ActiveModel::Validations
 
   # Email Address Regular Expression
-  EMAIL_FORMAT = /\A(([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)(\.{1}))*([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/.freeze
+  EMAIL_FORMAT = %r{\A(([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)(\.{1}))*([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z}
 
   # Overrides default initializer for compliance with form_for method in content_form view
   def initialize(attributes = {})

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -7,7 +7,8 @@ class BaseForm
   include ActiveModel::Validations
 
   # Email Address Regular Expression
-  EMAIL_FORMAT = %r{\A(([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)(\.{1}))*([\w\d!#\$%&'*+\-\/=?\^_`{|}~]+)@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z}
+  EMAIL_FORMAT = %r{\A(([\w\d!#$%&'*+\-/=?^_`{|}~]+)(\.{1}))*
+    ([\w\d!#$%&'*+\-/=?^_`{|}~]+)@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z}x.freeze
 
   # Overrides default initializer for compliance with form_for method in content_form view
   def initialize(attributes = {})

--- a/spec/forms/users_management/add_user_form_spec.rb
+++ b/spec/forms/users_management/add_user_form_spec.rb
@@ -37,8 +37,34 @@ describe UsersManagement::AddUserForm, type: :model do
       end
     end
 
-    context 'when email in invalid format' do
-      let(:email) { 'test,,,@test.com ' }
+    context 'when email in invalid format with comma' do
+      let(:email) { 'test,a@test.com' }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has a proper error message' do
+        subject.valid?
+        expect(subject.errors.messages[:email].join(',')).to include(
+          'Enter the user’s email address in a valid format'
+        )
+      end
+    end
+
+    context 'when email in invalid format with two consecutive dots' do
+      let(:email) { 'test..a@test.com ' }
+
+      it { is_expected.not_to be_valid }
+
+      it 'has a proper error message' do
+        subject.valid?
+        expect(subject.errors.messages[:email].join(',')).to include(
+          'Enter the user’s email address in a valid format'
+        )
+      end
+    end
+
+    context 'when email in invalid format with dot at the end' do
+      let(:email) { 'aaa.@test.com' }
 
       it { is_expected.not_to be_valid }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CAZB-3063

returned to regex, as Java Hibernate validator forbids two consecutive dots in email address, f.e. `this..isinvalidbecauseof2dots@test.com`

was done according to 
https://en.wikipedia.org/wiki/Email_address#Local-part
