### PR TITLE
[CAZB-3186] Read user email always from API

### DIFF
--- a/app/controllers/concerns/caz_lock.rb
+++ b/app/controllers/concerns/caz_lock.rb
@@ -19,8 +19,8 @@ module CazLock
 
   # Checks if selected caz locked
   def caz_locked?
-    return false if current_user.user_id == redis_value('user_id')
-    return false if current_user.account_id != redis_value('account_id')
+    return false if current_user.user_id == caz_lock_user_id
+    return false if current_user.account_id != caz_lock_account_id
 
     redis_value('caz_id') == caz_id_in_session
   end
@@ -59,11 +59,16 @@ module CazLock
 
   # Checks if current user is locked caz
   def current_user_payment?
-    current_user.user_id == redis_value('user_id')
+    current_user.user_id == caz_lock_user_id
   end
 
-  # Returns email for Caz lock process
-  def caz_lock_user_email
-    redis_value('email')
+  # Returns user_id for Caz lock process
+  def caz_lock_user_id
+    redis_value('user_id')
+  end
+
+  # Returns account_id for Caz lock process
+  def caz_lock_account_id
+    redis_value('account_id')
   end
 end

--- a/app/controllers/payments/payments_controller.rb
+++ b/app/controllers/payments/payments_controller.rb
@@ -247,7 +247,8 @@ module Payments
     def in_progress
       return determinate_lock_caz(@zone_id) unless caz_locked?
 
-      @user_locking_email = caz_lock_user_email
+      api_response = AccountsApi.user(account_id: caz_lock_account_id, account_user_id: caz_lock_user_id)
+      @user = UsersManagement::User.new(api_response)
       @zone = CleanAirZone.find(@zone_id)
     end
 

--- a/app/views/payments/payments/in_progress.html.haml
+++ b/app/views/payments/payments/in_progress.html.haml
@@ -9,7 +9,7 @@
       %h1.govuk-heading-l
         = title_and_header
       %p
-        = "#{@user_locking_email} is paying charges for #{@zone&.name} Clean Air Zone."
+        = "#{@user.email} is paying charges for #{@zone&.name} Clean Air Zone."
       %p
         To avoid the possibility of you both paying the same charge, you need to wait till they have finished 
         before making your payment.

--- a/features/step_definitions/payments_steps.rb
+++ b/features/step_definitions/payments_steps.rb
@@ -110,6 +110,7 @@ And('Second user starts payment in the same CAZ') do
     visit_caz_selection_page
     expect_path(matrix_payments_path)
   end
+  mock_second_user_details
 end
 
 Then('I should be on the payment in progress page') do

--- a/features/support/mock_users.rb
+++ b/features/support/mock_users.rb
@@ -33,6 +33,17 @@ module MockUsers
     allow(AccountsApi).to receive(:user).and_return(read_response('users_management/user.json'))
   end
 
+  def mock_second_user_details
+    api_response = {
+      name: 'Mary Smith',
+      email: 'second_user@email.com',
+      owner: true,
+      permissions: %w[MANAGE_VEHICLES MAKE_PAYMENTS]
+    }.stringify_keys
+    allow(AccountsApi).to receive(:user).with(account_id: account_id, account_user_id: second_user_id)
+                                        .and_return(api_response)
+  end
+
   def mock_account_details
     allow(AccountDetails::Api)
       .to receive(:account_details)

--- a/spec/requests/payments/payments/in_progress_spec.rb
+++ b/spec/requests/payments/payments/in_progress_spec.rb
@@ -7,8 +7,9 @@ describe 'PaymentsController - GET #in_progress' do
 
   let(:caz_id) { @uuid }
   let(:account_id) { SecureRandom.uuid }
+  let(:second_user_id) { SecureRandom.uuid }
   let(:user) { create_user(account_id: account_id, user_id: SecureRandom.uuid) }
-  let(:another_user) { create_user(account_id: account_id, user_id: SecureRandom.uuid) }
+  let(:second_user) { create_user(account_id: account_id, user_id: second_user_id) }
 
   context 'correct permissions' do
     let(:fleet) { create_chargeable_vehicles }
@@ -37,7 +38,9 @@ describe 'PaymentsController - GET #in_progress' do
 
     context 'with la in the session and CAZ locked by other user' do
       before do
-        add_caz_lock_to_redis(another_user)
+        sign_in second_user
+        mock_second_user_details(account_id, user.user_id)
+        add_caz_lock_to_redis(user)
         subject
       end
 

--- a/spec/support/users_management/mocked_responses.rb
+++ b/spec/support/users_management/mocked_responses.rb
@@ -13,6 +13,17 @@ module UsersManagement
       allow(AccountsApi).to receive(:user).and_return(read_response('users_management/user.json'))
     end
 
+    def mock_second_user_details(account_id, user_id)
+      api_response = {
+        name: 'Mary Smith',
+        email: 'second_user@email.com',
+        owner: true,
+        permissions: %w[MANAGE_VEHICLES MAKE_PAYMENTS]
+      }.stringify_keys
+      allow(AccountsApi).to receive(:user).with(account_id: account_id, account_user_id: user_id)
+                                          .and_return(api_response)
+    end
+
     def mock_update_user
       allow(AccountsApi).to receive(:update_user).and_return({})
     end


### PR DESCRIPTION
## Motivation and Context
Jira issue: https://eaflood.atlassian.net/browse/CAZB-3186

## Description
Call api to get email of the user which locks CAZ for payment

## How Has This Been Tested?
Manually, test added and fixed

## Screenshots (if appropriate):

## Checklist:
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
