### PR TITLE
[CAZB-2844] Hide Company payment history if no payer user for the account

### DIFF
--- a/app/api_wrappers/accounts_api.rb
+++ b/app/api_wrappers/accounts_api.rb
@@ -154,7 +154,7 @@ class AccountsApi < BaseApi # rubocop:disable Metrics/ClassLength
     #
     def users(account_id:)
       log_action('Getting users')
-      request(:get, "/accounts/#{account_id}/users")['users']
+      request(:get, "/accounts/#{account_id}/users")
     end
 
     ##

--- a/app/controllers/users_management/create_users_controller.rb
+++ b/app/controllers/users_management/create_users_controller.rb
@@ -22,10 +22,10 @@ module UsersManagement
     #    GET /users/new
     #
     def new
-      @back_button_url = if UsersManagement::Users.new(
+      @back_button_url = if UsersManagement::AccountUsers.new(
         account_id: current_user.account_id,
         user_id: current_user.user_id
-      ).filtered.any?
+      ).filtered_users.any?
                            users_path
                          else
                            dashboard_path
@@ -205,10 +205,10 @@ module UsersManagement
 
     # Do not allow owner to add more then 10 users
     def check_users_count
-      users = UsersManagement::Users.new(
+      users = UsersManagement::AccountUsers.new(
         account_id: current_user.account_id,
         user_id: current_user.user_id
-      ).filtered
+      ).filtered_users
       redirect_to users_path if users.count > 9
     end
   end

--- a/app/controllers/users_management/users_controller.rb
+++ b/app/controllers/users_management/users_controller.rb
@@ -19,7 +19,8 @@ module UsersManagement
     #
     def index
       clear_new_user if request.referer&.include?(confirmation_users_path)
-      @users = UsersManagement::Users.call(account_id: current_user.account_id, user_id: current_user.user_id)
+      @users = UsersManagement::AccountUsers.call(account_id: current_user.account_id,
+                                                  user_id: current_user.user_id)
     end
 
     private

--- a/app/services/users_management/account_users.rb
+++ b/app/services/users_management/account_users.rb
@@ -6,7 +6,7 @@ module UsersManagement
   ##
   # Service used to fetch the list of users and display only not owner and not removed users
   #
-  class Users < BaseService
+  class AccountUsers < BaseService
     ##
     # Initializer method
     #
@@ -28,20 +28,30 @@ module UsersManagement
     end
 
     # Filtering out removed users and owner from the api response
-    def filtered
-      api_call.reject { |user| filter_users(user) }
+    def filtered_users
+      users.reject { |user| filter_users(user) }
+    end
+
+    # Returns information if account has multiple payers users
+    def multi_payer_account?
+      api_call['multiPayerAccount']
     end
 
     private
 
+    # Gets users from the API response
+    def users
+      api_call['users']
+    end
+
     # Filtering out removed users and owner from the api response and then sorts by downcase name in alphabetical order
     def filtered_and_sorted
-      api_call.reject { |user| filter_users(user) }.sort_by { |user| user['name'].downcase }
+      users.reject { |user| filter_users(user) }.sort_by { |user| user['name'].downcase }
     end
 
     # Call the api go get all users
     def api_call
-      AccountsApi.users(account_id: account_id)
+      @api_call ||= AccountsApi.users(account_id: account_id)
     end
 
     # Checks if user owner or removed

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -32,4 +32,4 @@
       = render 'make_payment' if allow_make_payments?
     = render 'manage_users' if allow_manage_users?
     = render 'user_payment_history' if allow_make_payments?
-    = render 'company_payment_history' if allow_view_payment_history?
+    = render 'company_payment_history' if allow_view_payment_history? && @multi_payer_account

--- a/features/dashboard/user_dashboard.feature
+++ b/features/dashboard/user_dashboard.feature
@@ -47,3 +47,5 @@ Feature: Dashboard
       And I should not see 'Make a payment' link
       And I should not see 'Manage users' link
       And I should not see 'Your payment history' link
+    When I navigate to a Dashboard page without any payers users
+      And I should not see 'Royal Mail payment history' link

--- a/features/step_definitions/dashboard_steps.rb
+++ b/features/step_definitions/dashboard_steps.rb
@@ -29,6 +29,11 @@ When('I navigate to a Dashboard page with Direct Debits enabled') do
   visit dashboard_path
 end
 
+When('I navigate to a Dashboard page without any payers users') do
+  mock_empty_users_list
+  visit dashboard_path
+end
+
 When('I navigate to a Dashboard page with {string} permission') do |permission|
   mock_direct_debit_enabled
   mock_vehicles_in_fleet

--- a/features/step_definitions/debits_steps.rb
+++ b/features/step_definitions/debits_steps.rb
@@ -84,6 +84,7 @@ Then('I should be on the Payment unsuccessful page') do
 end
 
 Given('I have inactive mandates for each CAZ but one of them is disabled') do
+  mock_users
   mock_vehicles_in_fleet
   mock_direct_debit_enabled
   api_response = read_response('/debits/inactive_mandates.json')

--- a/features/step_definitions/payment_history_steps.rb
+++ b/features/step_definitions/payment_history_steps.rb
@@ -3,6 +3,7 @@
 Given('I visit the Company payment history page') do
   mock_vehicles_in_fleet
   mock_payment_history
+  mock_users
   login_user(permissions: %w[VIEW_PAYMENTS MAKE_PAYMENTS])
   visit company_payment_history_path
 end
@@ -16,6 +17,7 @@ Given('I go to the User payment history page') do
 end
 
 Given('I visit the User payment history page') do
+  mock_users
   mock_vehicles_in_fleet
   mock_payment_history
   login_user(permissions: %w[VIEW_PAYMENTS MAKE_PAYMENTS])
@@ -23,11 +25,13 @@ Given('I visit the User payment history page') do
 end
 
 Given('I want visit the Payments details page from Company payments history page') do
+  mock_users
   mock_api_and_sign_in_user
   visit company_payment_history_path
 end
 
 Given('I want visit the Payments details page from User payments history page') do
+  mock_users
   mock_api_and_sign_in_user
   visit user_payment_history_path
 end

--- a/features/step_definitions/vehicles_management/fleets_steps.rb
+++ b/features/step_definitions/vehicles_management/fleets_steps.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 Given('I have no vehicles in my fleet') do
+  mock_users
   mock_empty_fleet
 end
 
 Given('I have no vehicles in my fleet and visit the manage vehicles page') do
   mock_empty_fleet
+  mock_users
   login_user({ permissions: 'MANAGE_VEHICLES' })
   visit fleets_path
 end
@@ -26,6 +28,7 @@ end
 
 When('I visit the submission method page') do
   mock_vehicles_in_fleet
+  mock_users
   login_user({ permissions: 'MANAGE_VEHICLES' })
   visit submission_method_fleets_path
 end
@@ -51,6 +54,7 @@ Then('I should be on the upload page') do
 end
 
 When('I have vehicles in my fleet') do
+  mock_users
   mock_clean_air_zones
   mock_vehicles_in_fleet
   mock_caz_mandates
@@ -62,6 +66,7 @@ When('I have undetermined vehicles in my fleet') do
   mock_undetermined_vehicles
   mock_caz_mandates
   mock_direct_debit_enabled
+  mock_users
 end
 
 When('I want to pay for CAZ which started charging {int} days ago') do |start_days_ago|
@@ -74,20 +79,24 @@ When('I want to pay for CAZ which started charging {int} days ago') do |start_da
   }]
   mock_clean_air_zones(caz_list)
   mock_unpaid_vehicles_in_fleet
+  mock_users
 end
 
 When('I want to pay for active for charging CAZ') do
   caz_list = read_response('caz_list_active.json')['cleanAirZones']
   mock_clean_air_zones(caz_list)
   mock_unpaid_vehicles_in_fleet
+  mock_users
 end
 
 When('I have vehicles in my fleet that are not paid') do
+  mock_users
   mock_clean_air_zones
   mock_unpaid_vehicles_in_fleet
 end
 
 When('I have no chargeable vehicles in my fleet') do
+  mock_users
   mock_clean_air_zones
   mock_unchargeable_vehicles
 end

--- a/features/step_definitions/vehicles_management/uploads_step.rb
+++ b/features/step_definitions/vehicles_management/uploads_step.rb
@@ -67,8 +67,9 @@ def attach_valid_csv_file
   attach_file(:file, File.join('spec', 'fixtures', 'uploads', 'fleet.csv'))
 end
 
-def mock_processing_page(large_fleet:)
+def mock_processing_page(large_fleet:) # rubocop:disable Metrics/MethodLength
   mock_vehicles_in_fleet
+  mock_users
   login_user(permissions: %w[MANAGE_VEHICLES MAKE_PAYMENTS], account_id: account_id)
   REDIS.hmset(
     "account_id_#{account_id}",

--- a/features/step_definitions/vehicles_management/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_management/vehicles_steps.rb
@@ -2,6 +2,7 @@
 
 When('I visit the enter details page') do
   mock_vehicles_in_fleet
+  mock_users
   login_user(permissions: 'MANAGE_VEHICLES')
   visit enter_details_vehicles_path
 end

--- a/features/support/mock_users.rb
+++ b/features/support/mock_users.rb
@@ -6,25 +6,30 @@ module MockUsers
   end
 
   def mock_empty_users_list
-    allow(AccountsApi).to receive(:users).and_return([])
+    allow(AccountsApi).to receive(:users).and_return(empty_users_api_response)
   end
 
   def mock_more_then_ten_users
     api_response = users_api_response
-    api_response << users_api_response.last
+    api_response['users'] << users_api_response['users'].last
     allow(AccountsApi).to receive(:users).and_return(api_response)
   end
 
   def mock_user_on_list # rubocop:disable Metrics/MethodLength
     user = new_user
     api_response = {
-      accountUserId: user.user_id,
-      name: 'Mary Smith',
-      email: 'test@example.com',
-      owner: true,
-      removed: false
+      multiPayerAccount: true,
+      users: [
+        {
+          accountUserId: user.user_id,
+          name: 'Mary Smith',
+          email: 'test@example.com',
+          owner: true,
+          removed: false
+        }.stringify_keys
+      ]
     }.stringify_keys
-    allow(AccountsApi).to receive(:users).and_return([api_response])
+    allow(AccountsApi).to receive(:users).and_return(api_response)
     allow_any_instance_of(User).to receive(:authentication).and_return(user)
     fill_sign_in_form
   end
@@ -65,7 +70,11 @@ module MockUsers
   private
 
   def users_api_response
-    read_response('users_management/users.json')['users']
+    read_response('users_management/users.json')
+  end
+
+  def empty_users_api_response
+    read_response('users_management/empty_users.json')
   end
 end
 

--- a/spec/api_wrappers/accounts_api/users_spec.rb
+++ b/spec/api_wrappers/accounts_api/users_spec.rb
@@ -20,7 +20,14 @@ describe 'AccountsApi.users - GET' do
     end
 
     it 'returns proper fields' do
-      expect(subject.first.keys).to contain_exactly(
+      expect(subject.keys).to contain_exactly(
+        'users',
+        'multiPayerAccount'
+      )
+    end
+
+    it 'returns proper fields for users collection' do
+      expect(subject['users'].first.keys).to contain_exactly(
         'accountUserId',
         'name',
         'email',

--- a/spec/fixtures/responses/users_management/empty_users.json
+++ b/spec/fixtures/responses/users_management/empty_users.json
@@ -1,0 +1,4 @@
+{
+    "multiPayerAccount": false,
+    "users": []
+}

--- a/spec/fixtures/responses/users_management/users.json
+++ b/spec/fixtures/responses/users_management/users.json
@@ -1,4 +1,5 @@
 {
+    "multiPayerAccount": true,
     "users": [
         {
             "accountUserId": "4fedcde2-d18d-4f49-8f71-f9fac3f38158",

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -50,6 +50,7 @@ describe DashboardController do
     context 'when user is signed in with password that is about to expire in 8 days' do
       before do
         mock_fleet
+        mock_users
         sign_in create_user(
           permissions: [],
           days_to_password_expiry: 8

--- a/spec/requests/users_management/create_users/new_spec.rb
+++ b/spec/requests/users_management/create_users/new_spec.rb
@@ -27,7 +27,7 @@ describe 'UsersManagement::CreateUsersController - GET #new' do
 
     context 'when api returns empty users' do
       before do
-        allow(AccountsApi).to receive(:users).and_return([])
+        mock_empty_users_list
         subject
       end
 

--- a/spec/services/users_management/account_users_spec.rb
+++ b/spec/services/users_management/account_users_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UsersManagement::Users do
+describe UsersManagement::AccountUsers do
   subject { described_class.call(account_id: @uuid, user_id: @uuid) }
 
   describe '#call' do
@@ -28,7 +28,7 @@ describe UsersManagement::Users do
   end
 
   describe '#filtered' do
-    subject { described_class.new(account_id: @uuid, user_id: @uuid).filtered }
+    subject { described_class.new(account_id: @uuid, user_id: @uuid).filtered_users }
 
     before { mock_users }
 

--- a/spec/support/users_management/mocked_responses.rb
+++ b/spec/support/users_management/mocked_responses.rb
@@ -5,7 +5,12 @@
 module UsersManagement
   module MockedResponses
     def mock_users
-      api_response = read_response('users_management/users.json')['users']
+      api_response = read_response('users_management/users.json')
+      allow(AccountsApi).to receive(:users).and_return(api_response)
+    end
+
+    def mock_empty_users_list
+      api_response = read_response('users_management/empty_users.json')
       allow(AccountsApi).to receive(:users).and_return(api_response)
     end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira card: https://eaflood.atlassian.net/browse/CAZB-2844
We need to hide the payments history from the dashboard if no payer user was assigned to the user. 

## Description
<!--- Describe your changes in detail -->
Used new attribute from the `/users/` endpoint 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on two accounts: 
1. New account without any users
2. Account with users but without paying access
3. Account with users who can make payments. 
 
## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
