### PR TITLE
[CAZB-2669, CAZB-2637] Align error message for password complexity

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -208,7 +208,7 @@ class PasswordsController < ApplicationController
   def parse_422_error(code)
     case code
     when 'passwordNotValid'
-      [I18n.t('new_password_form.errors.password_complexity')]
+      [I18n.t('input_form.errors.password_complexity')]
     when 'newPasswordReuse'
       [I18n.t('update_password_form.errors.password_reused')]
     else

--- a/app/forms/update_password_form.rb
+++ b/app/forms/update_password_form.rb
@@ -43,7 +43,7 @@ class UpdatePasswordForm < NewPasswordForm
   def parse_422_error(code)
     case code
     when 'passwordNotValid'
-      errors.add(:password, :invalid, message: I18n.t('new_password_form.errors.password_complexity'))
+      errors.add(:password, :invalid, message: I18n.t('input_form.errors.password_complexity'))
     when 'oldPasswordInvalid'
       errors.add(:old_password, :invalid, message: I18n.t('update_password_form.errors.old_password_invalid'))
     when 'newPasswordReuse'

--- a/app/forms/users_management/set_up_account_form.rb
+++ b/app/forms/users_management/set_up_account_form.rb
@@ -34,7 +34,7 @@ module UsersManagement
       errors.add(:token, :invalid, message: I18n.t('token_form.token_invalid'))
       false
     rescue BaseApi::Error422Exception
-      add_password_errors(I18n.t('new_password_form.errors.password_complexity'))
+      add_password_errors(I18n.t('input_form.errors.password_complexity'))
       false
     end
 

--- a/app/services/account_details/update_email.rb
+++ b/app/services/account_details/update_email.rb
@@ -55,7 +55,7 @@ module AccountDetails
     def parse_422_error(code)
       case code
       when 'passwordNotValid'
-        [I18n.t('new_password_form.errors.password_complexity')]
+        [I18n.t('input_form.errors.password_complexity')]
       when 'newPasswordReuse'
         [I18n.t('update_password_form.errors.password_reused')]
       when 'expired', 'invalid'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
       missing: '%{attribute} is required'
       invalid_format: '%{attribute} is in an invalid format'
       maximum_length: '%{attribute} is too long (maximum is 45 characters)'
-      password_complexity: Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character
+      password_complexity: Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character
     labels:
       email: Enter your email address
       email_confirmation: Confirm your email address
@@ -64,7 +64,6 @@ en:
       password_not_equal: Enter a password and password confirmation that are the same
       password_missing: Enter your new password
       password_confirmation_missing: Confirm your new password
-      password_complexity: Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character
   update_password_form:
     errors:
       old_password_missing: Enter your old password

--- a/features/account_details/emails.feature
+++ b/features/account_details/emails.feature
@@ -43,7 +43,7 @@ Feature: Email update
     Given I visit the Confirm email update page
     When I enter too easy password and confirmation password
       And I press 'Sign in' button
-    Then I should see 'Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character' 2 times
+    Then I should see 'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character' 2 times
     When I enter reused old password
       And I press 'Sign in' button
     Then I should see 'You have already used that password, choose a new one' 2 times

--- a/features/account_details/passwords.feature
+++ b/features/account_details/passwords.feature
@@ -17,7 +17,7 @@ Feature: Password update
     When I fill invalid old password and press 'Save changes'
       Then I should see 'The password you entered is incorrect' 2 times
     When I fill in a password not complex enough and press 'Save changes'
-      Then I should see 'Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character' 2 times
+      Then I should see 'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character' 2 times
     When I fill in a password that was used before and press 'Save changes'
       Then I should see 'You have already used that password, choose a new one' 2 times
     When I fill passwords that do not match and press 'Save changes'

--- a/features/passwords/password_reset.feature
+++ b/features/passwords/password_reset.feature
@@ -35,7 +35,7 @@ Feature: Password reset
     Given I visit passwords
     When I enter too easy password and confirmation
       And I press 'Update password' button
-    Then I should see 'Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character' 2 times
+    Then I should see 'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character' 2 times
     When I try to reuse old password
       And I press 'Update password' button
     Then I should see 'You have already used that password, choose a new one' 2 times

--- a/features/passwords/password_update.feature
+++ b/features/passwords/password_update.feature
@@ -29,7 +29,7 @@ Feature: Password reset
     When I fill invalid old password and press 'Continue'
       Then I should see 'The password you entered is incorrect' 2 times
     When I fill in a password not complex enough and press 'Continue'
-      Then I should see 'Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character' 2 times
+      Then I should see 'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character' 2 times
     When I fill in a password that was used before and press 'Continue'
       Then I should see 'You have already used that password, choose a new one' 2 times
     When I fill passwords that do not match and press 'Continue'

--- a/features/users_management/account_set_up.feature
+++ b/features/users_management/account_set_up.feature
@@ -50,4 +50,4 @@ Feature: Account set up
     Given I am on the set up account page
       And I provide exact but invalid passwords
     When I press 'Continue' button
-      Then I should see 'Enter a password at least 12 characters long, including at least 1 upper case letter, 1 number, and a special character' 3 times
+      Then I should see 'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and a special character' 3 times

--- a/spec/forms/update_password_form_spec.rb
+++ b/spec/forms/update_password_form_spec.rb
@@ -69,7 +69,10 @@ describe UpdatePasswordForm, type: :model do
     end
 
     it 'has a proper password message' do
-      expect(subject.errors[:password]).to include(I18n.t('new_password_form.errors.password_complexity'))
+      expect(subject.errors[:password]).to include(
+        'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number and '\
+        'a special character'
+      )
     end
   end
 

--- a/spec/forms/users_management/set_up_account_form_spec.rb
+++ b/spec/forms/users_management/set_up_account_form_spec.rb
@@ -87,7 +87,8 @@ describe UsersManagement::SetUpAccountForm, type: :model do
 
     it 'has correct password fields message' do
       subject.submit
-      error_message = I18n.t('new_password_form.errors.password_complexity')
+      error_message = 'Enter a password at least 12 characters long including at least 1 upper case letter, '\
+                      '1 number and a special character'
       expect(subject.errors.messages[:password]).to include(error_message)
       expect(subject.errors.messages[:password_confirmation]).to include(error_message)
     end

--- a/spec/requests/account_details/passwords/update_spec.rb
+++ b/spec/requests/account_details/passwords/update_spec.rb
@@ -93,7 +93,10 @@ describe 'AccountDetails::PasswordsController - PATCH #update' do
       end
 
       it 'assigns a proper error message' do
-        expect(assigns(:errors)[:password]).to include(I18n.t('new_password_form.errors.password_complexity'))
+        expect(assigns(:errors)[:password]).to include(
+          'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number '\
+          'and a special character'
+        )
       end
     end
 

--- a/spec/requests/passwords/create_spec.rb
+++ b/spec/requests/passwords/create_spec.rb
@@ -92,7 +92,10 @@ describe 'PasswordsController - POST #create' do
 
       it 'assigns a proper error message' do
         subject
-        expect(assigns(:errors)[:password]).to include(I18n.t('new_password_form.errors.password_complexity'))
+        expect(assigns(:errors)[:password]).to include(
+          'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number '\
+          'and a special character'
+        )
       end
     end
 

--- a/spec/requests/passwords/update_spec.rb
+++ b/spec/requests/passwords/update_spec.rb
@@ -76,7 +76,10 @@ describe 'PasswordsController - PATCH #update' do
       end
 
       it 'assigns a proper error message' do
-        expect(assigns(:errors)[:password]).to include(I18n.t('new_password_form.errors.password_complexity'))
+        expect(assigns(:errors)[:password]).to include(
+          'Enter a password at least 12 characters long including at least 1 upper case letter, 1 number '\
+          'and a special character'
+        )
       end
     end
 

--- a/spec/requests/users_management/create_users/confirm_set_up_spec.rb
+++ b/spec/requests/users_management/create_users/confirm_set_up_spec.rb
@@ -44,8 +44,10 @@ describe 'UsersManagement::CreateUsersController - POST #confirm_set_up' do
     it 'provides proper error messages' do
       errors = {
         token: nil,
-        password: I18n.t('new_password_form.errors.password_complexity'),
-        password_confirmation: I18n.t('new_password_form.errors.password_complexity')
+        password: 'Enter a password at least 12 characters long including at least 1 upper case letter, '\
+                   '1 number and a special character',
+        password_confirmation: 'Enter a password at least 12 characters long including at least 1 upper case'\
+                   ' letter, 1 number and a special character'
       }
 
       expect(flash[:errors]).to eq(errors)

--- a/spec/services/account_details/update_email_spec.rb
+++ b/spec/services/account_details/update_email_spec.rb
@@ -56,7 +56,8 @@ describe AccountDetails::UpdateEmail do
 
         it 'has a proper error message' do
           expect(subject.errors[:password].first.include?(
-                   'Enter a password at least 12 characters long, including at least 1 upper case letter'
+                   'Enter a password at least 12 characters long including at least 1 upper case letter, '\
+                   '1 number and a special character'
                  )).to be_truthy
         end
       end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-2637
https://eaflood.atlassian.net/browse/CAZB-2865
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
