### PR TITLE
[CAZB-3118] Added CSV upload lambda timeout error

### DIFF
--- a/app/services/vehicles_management/upload_file.rb
+++ b/app/services/vehicles_management/upload_file.rb
@@ -88,7 +88,7 @@ module VehiclesManagement
       raise CsvUploadException, I18n.t('csv.errors.base')
     rescue Aws::S3::Errors::ServiceError => e
       log_error e
-      raise CsvUploadException, I18n.t('csv.errors.base')
+      raise CsvUploadException, format_error_message(e.message)
     end
 
     # Uploading file to AWS S3.
@@ -108,6 +108,11 @@ module VehiclesManagement
 
     def metadata
       { 'account-user-id': user.user_id, 'account-id': user.account_id }
+    end
+
+    # Formats exception error message
+    def format_error_message(error)
+      error.include?('Lambda timeout') ? I18n.t('csv.errors.size_too_big') : I18n.t('csv.errors.base')
     end
 
     # Attributes used internally to save values.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,7 @@ en:
       base: The selected file could not be uploaded – try again
       no_file: Select a CSV file to upload
       invalid_ext: The selected file must be in a .CSV format
+      size_too_big: The file you are uploading contains more than 50k vehicles, the maximum number allowed
   token_form:
     token_missing: Authorisation token is missing
     token_invalid: Authorisation token is invalid or has expired

--- a/features/step_definitions/vehicles_management/uploads_step.rb
+++ b/features/step_definitions/vehicles_management/uploads_step.rb
@@ -61,6 +61,14 @@ When('I upload a csv file whose size is too big') do
   click_button 'Upload file'
 end
 
+When('My upload results with lambda timeout') do
+  allow(VehiclesManagement::UploadFile)
+    .to receive(:call)
+    .and_raise(CsvUploadException.new(I18n.t('csv.errors.size_too_big')))
+  attach_valid_csv_file
+  click_button 'Upload file'
+end
+
 private
 
 def attach_valid_csv_file

--- a/features/vehicles_management/uploads.feature
+++ b/features/vehicles_management/uploads.feature
@@ -90,6 +90,12 @@ Feature: Uploads
     When I upload a csv file whose size is too big
     Then I should see 'The CSV must be smaller than 50MB'
 
+  Scenario: Upload a csv file that timeouts lambda
+    Given I have no vehicles in my fleet
+      And I visit the upload page
+    When My upload results with lambda timeout
+      Then I should see 'The file you are uploading contains more than 50k vehicles, the maximum number allowed'
+
   Scenario: Upload in calculating chargeability status and number of vehicles less than the threshold
     When I am on the processing page and number of vehicles less than the threshold
       And My upload is calculating

--- a/spec/services/vehicles_management/upload_file_spec.rb
+++ b/spec/services/vehicles_management/upload_file_spec.rb
@@ -72,6 +72,20 @@ describe VehiclesManagement::UploadFile do
           expect { subject }.to raise_exception(CsvUploadException, I18n.t('csv.errors.base'))
         end
       end
+
+      context 'when S3 raises a lambda timeout exception' do
+        before do
+          lambda_timeout_error = 'Lambda timeout exception. Please contact administrator to get assistance'
+
+          allow_any_instance_of(Aws::S3::Object)
+            .to receive(:upload_file)
+            .and_raise(Aws::S3::Errors::ServiceError.new('', lambda_timeout_error))
+        end
+
+        it 'raises a proper exception' do
+          expect { subject }.to raise_exception(CsvUploadException, I18n.t('csv.errors.size_too_big'))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3118

## Description
<!--- Describe your changes in detail -->
If an S3 exception contains string `Lambda timeout exception`, `CsvUploadException` is thrown with more user friendly error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cucumber, rspec

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5519481/95713372-b488e500-0c66-11eb-9cd6-82f1a56f7f88.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
