### PR TITLE
[CAZB-3352] Redirect to the failure page on duplicated dd payment

### DIFF
--- a/app/controllers/direct_debits/debits_controller.rb
+++ b/app/controllers/direct_debits/debits_controller.rb
@@ -55,7 +55,7 @@ module DirectDebits
       details = DirectDebits::Details.new(create_direct_debit_payment)
       payment_details_to_session(details)
       redirect_to success_debits_path
-    rescue BaseApi::Error400Exception
+    rescue BaseApi::Error400Exception, BaseApi::Error422Exception
       redirect_to failure_debits_path
     end
 

--- a/spec/requests/direct_debits/debits/initiate_spec.rb
+++ b/spec/requests/direct_debits/debits/initiate_spec.rb
@@ -46,6 +46,18 @@ describe 'DirectDebits::DebitsController - POST #initiate' do
         expect(response).to redirect_to(failure_debits_path)
       end
     end
+
+    context 'when api returns 422 status' do
+      before do
+        allow(DebitsApi).to receive(:create_payment)
+          .and_raise(BaseApi::Error422Exception.new(422, '', ''))
+        subject
+      end
+
+      it 'redirects to the failure dd payment page' do
+        expect(response).to redirect_to(failure_debits_path)
+      end
+    end
   end
 
   it_behaves_like 'incorrect permissions'


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3352
https://github.com/InformedSolutions/JAQU-CAZ-Payments-API/pull/381/files
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
