### PR TITLE
[CAZB-3163] Disable CSV export link after click

### DIFF
--- a/app/javascript/packs/export_button_notice.js
+++ b/app/javascript/packs/export_button_notice.js
@@ -1,0 +1,11 @@
+// Reveals download in progress message
+const btn = document.getElementById("csv-export");
+btn.addEventListener("click", () => {
+  const message = document.getElementById("csv-export__notice");
+  message.style.display = "block";
+  btn.className = "govuk-link disabled-link";
+  setTimeout(() => {
+    btn.className = "govuk-link";
+    message.style.display = "none";
+  }, 5000);
+});

--- a/app/views/vehicles_management/fleets/index.html.haml
+++ b/app/views/vehicles_management/fleets/index.html.haml
@@ -58,7 +58,6 @@
       %p
         = link_to('Download a spreadsheet (CSV) of the charges you would pay to drive in all Clean Air Zones',
                   export_fleets_path,
-                  onclick: "document.getElementById('csv-export__notice').style.display = 'block'",
                   id: 'csv-export',
                   class: 'govuk-link')
 

--- a/app/views/vehicles_management/fleets/index.html.haml
+++ b/app/views/vehicles_management/fleets/index.html.haml
@@ -64,6 +64,8 @@
 
       %p{id: 'csv-export__notice', style: 'display: none;'}
         Your export is downloading...
+      
+      = javascript_pack_tag 'export_button_notice'
 
       - if @fleet.any_undetermined_vehicles
         %details.govuk-details{'data-module': 'govuk-details'}


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3163

## Description
<!--- Describe your changes in detail -->
Link will now be disabled after click for 5 seconds. After this time it will be enabled and `Your export is downloading...` message will be hidden

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5519481/95978765-e773da00-0e1a-11eb-86f3-d8835502213c.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
