### PR TITLE
[CAZB-3118] Revert lambda timeout error handling

### DIFF
--- a/app/controllers/vehicles_management/uploads_controller.rb
+++ b/app/controllers/vehicles_management/uploads_controller.rb
@@ -130,14 +130,9 @@ module VehiclesManagement
     # Handles failed scenario after CSV processing
     def handle_failed_processing(job)
       clear_upload_job_data
-      @job_errors = job[:errors].map { |error| format_error_message(error) }
+      @job_errors = job[:errors]
       @vehicles_present = !current_user.fleet.empty?
       render :index
-    end
-
-    # Formats failed scenario error message
-    def format_error_message(error)
-      error.include?('Lambda timeout') ? I18n.t('csv.errors.size_too_big') : error
     end
   end
 end

--- a/features/step_definitions/vehicles_management/uploads_step.rb
+++ b/features/step_definitions/vehicles_management/uploads_step.rb
@@ -61,14 +61,6 @@ When('I upload a csv file whose size is too big') do
   click_button 'Upload file'
 end
 
-When('My upload results with lambda timeout') do
-  allow(VehiclesManagement::UploadFile)
-    .to receive(:call)
-    .and_raise(CsvUploadException.new(I18n.t('csv.errors.size_too_big')))
-  attach_valid_csv_file
-  click_button 'Upload file'
-end
-
 private
 
 def attach_valid_csv_file

--- a/features/vehicles_management/uploads.feature
+++ b/features/vehicles_management/uploads.feature
@@ -90,12 +90,6 @@ Feature: Uploads
     When I upload a csv file whose size is too big
     Then I should see 'The CSV must be smaller than 50MB'
 
-  Scenario: Upload a csv file that timeouts lambda
-    Given I have no vehicles in my fleet
-      And I visit the upload page
-    When My upload results with lambda timeout
-      Then I should see 'The file you are uploading contains more than 50k vehicles, the maximum number allowed'
-
   Scenario: Upload in calculating chargeability status and number of vehicles less than the threshold
     When I am on the processing page and number of vehicles less than the threshold
       And My upload is calculating

--- a/spec/requests/vehicles_management/uploads/processing_spec.rb
+++ b/spec/requests/vehicles_management/uploads/processing_spec.rb
@@ -101,23 +101,6 @@ describe 'VehiclesManagement::UploadsController - GET #processing' do
             expect(REDIS.hget(upload_job_redis_key, 'job_id')).to be_nil
           end
         end
-
-        describe 'FAILURE - lambda timeout' do
-          let(:status) { 'FAILURE' }
-          let(:errors) { ['Lambda timeout exception. Please contact administrator to get assistance'] }
-
-          it 'renders the upload page' do
-            expect(response).to render_template(:index)
-          end
-
-          it 'assigns errors' do
-            expect(assigns[:job_errors]).to eq([I18n.t('csv.errors.size_too_big')])
-          end
-
-          it 'deletes job data from redis' do
-            expect(REDIS.hget(upload_job_redis_key, 'job_id')).to be_nil
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3118

## Description
<!--- Describe your changes in detail -->
Reverted changes made to handle lambda timeout error.
Correct error message content will be set on backend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
