### PR TITLE
[CAZB-3387] Validate email length in Update Email flow

### DIFF
--- a/app/forms/account_details/edit_user_email_form.rb
+++ b/app/forms/account_details/edit_user_email_form.rb
@@ -17,8 +17,8 @@ module AccountDetails
       message: I18n.t('edit_user_email_form.errors.email_missing')
     }
 
-    # validates +email+ length
-    validates :email, length: {
+    # validates +email+ and +confirmation+ length
+    validates :email, :confirmation, length: {
       maximum: MAX_EMAIL_LENGTH,
       too_long: I18n.t('edit_user_email_form.errors.email_too_long')
     }

--- a/app/forms/account_details/edit_user_email_form.rb
+++ b/app/forms/account_details/edit_user_email_form.rb
@@ -32,7 +32,7 @@ module AccountDetails
     validate :correct_email_confirmation
 
     # validates +email+ against duplication
-    validate :email_not_duplicated, if: -> { email.present? && email == confirmation }
+    validate :email_not_duplicated, if: :check_if_email_unique?
 
     # Checks if user reused their current email
     def current_email_reuse?
@@ -40,6 +40,11 @@ module AccountDetails
     end
 
     private
+
+    # Determines if email uniqueness should be checked
+    def check_if_email_unique?
+      email.present? && email == confirmation && email.length <= MAX_EMAIL_LENGTH
+    end
 
     # Checks if +email+ and +confirmation+ are same.
     # If not, add error message to +email+ and +confirmation+

--- a/app/forms/account_details/edit_user_email_form.rb
+++ b/app/forms/account_details/edit_user_email_form.rb
@@ -9,9 +9,18 @@ module AccountDetails
     # Attributes accessor
     attr_accessor :account_id, :current_email, :email, :confirmation
 
+    # Maximum length for email address
+    MAX_EMAIL_LENGTH = 128
+
     # validates +email+ and +confirmation+ presence
     validates :email, :confirmation, presence: {
       message: I18n.t('edit_user_email_form.errors.email_missing')
+    }
+
+    # validates +email+ length
+    validates :email, length: {
+      maximum: MAX_EMAIL_LENGTH,
+      too_long: I18n.t('edit_user_email_form.errors.email_too_long')
     }
 
     # validates +email+ and +confirmation+ format

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       email_duplicated: Email address already exists
       email_invalid_format: Enter email in a valid format
       email_missing: Enter an email address
+      email_too_long: Enter an email address that is less than 129 characters
       emails_not_equal: Email address and email confirmation must be the same
     labels:
       email: Email address

--- a/features/account_details/emails.feature
+++ b/features/account_details/emails.feature
@@ -18,6 +18,10 @@ Feature: Email update
       And I press 'Save and continue' button
       Then I should see 'Enter an email address' 3 times
     When I enter change my email page
+      And I fill in email that is too long
+      And I press 'Save and continue' button
+      Then I should see 'Enter an email address that is less than 129 characters' 2 times
+    When I enter change my email page
       And I fill in email with email with invalid format
       And I press 'Save and continue' button
       Then I should see 'Enter email in a valid format' 2 times
@@ -31,7 +35,7 @@ Feature: Email update
       And I press 'Save and continue' button
       Then I should be on the verification email sent page
 
-  Scenario: Changing email address when is logged in
+  Scenario: Confirming email address change when logged in
     Given I visit the Confirm email update page
     Then I should see 'Email address change'
     When I enter only password
@@ -44,13 +48,13 @@ Feature: Email update
       And I press 'Sign in' button
     Then I should be on the Dashboard page
 
-  Scenario: Changing email address when is not logged in
+  Scenario: Confirming email address change when not logged in
     Given I visit the Confirm email update page when is not logged in
     When I enter valid password and confirmation
       And I press 'Sign in' button
     Then I should be on the Dashboard page
 
-  Scenario: Changing email address when not enough complex or reused password or when token expired
+  Scenario: Confirming email address change when not enough complex or reused password or when token expired
     Given I visit the Confirm email update page
     When I enter too easy password and confirmation password
       And I press 'Sign in' button

--- a/features/account_details/emails.feature
+++ b/features/account_details/emails.feature
@@ -20,7 +20,7 @@ Feature: Email update
     When I enter change my email page
       And I fill in email that is too long
       And I press 'Save and continue' button
-      Then I should see 'Enter an email address that is less than 129 characters' 2 times
+      Then I should see 'Enter an email address that is less than 129 characters' 3 times
     When I enter change my email page
       And I fill in email with email with invalid format
       And I press 'Save and continue' button

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -14,7 +14,6 @@ And('I fill in email with empty string') do
 end
 
 And('I fill in email that is too long') do
-  mock_successful_user_validation
   fill_in('primary_user_email', with: 'a' * 129)
   fill_in('primary_user_confirmation', with: 'a' * 129)
 end

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -13,6 +13,10 @@ And('I fill in email with empty string') do
   fill_in('primary_user_email', with: '')
 end
 
+And('I fill in email that is too long') do
+  fill_in('primary_user_email', with: 'a' * 130)
+end
+
 And('I fill in email with email with invalid format') do
   mock_successful_user_validation
   fill_in('primary_user_email', with: 'invalid-email')

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -14,7 +14,9 @@ And('I fill in email with empty string') do
 end
 
 And('I fill in email that is too long') do
-  fill_in('primary_user_email', with: 'a' * 130)
+  mock_successful_user_validation
+  fill_in('primary_user_email', with: 'a' * 129)
+  fill_in('primary_user_confirmation', with: 'a' * 129)
 end
 
 And('I fill in email with email with invalid format') do

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -14,8 +14,8 @@ And('I fill in email with empty string') do
 end
 
 And('I fill in email that is too long') do
-  fill_in('primary_user_email', with: 'a' * 129)
-  fill_in('primary_user_confirmation', with: 'a' * 129)
+  fill_in('primary_user_email', with: "#{'a' * 120}@test.com")
+  fill_in('primary_user_confirmation', with: "#{'a' * 120}@test.com")
 end
 
 And('I fill in email with email with invalid format') do

--- a/spec/forms/account_details/edit_user_email_form_spec.rb
+++ b/spec/forms/account_details/edit_user_email_form_spec.rb
@@ -109,6 +109,27 @@ describe AccountDetails::EditUserEmailForm, type: :model do
     end
   end
 
+  context 'when provided email is too long' do
+    before { allow(AccountsApi::Accounts).to receive(:user_validations).and_return(true) }
+
+    let(:email) { "#{'a' * 129}@test.com" }
+    let(:confirmation) { "#{'a' * 129}@test.com" }
+
+    before { subject.valid? }
+
+    it { is_expected.not_to be_valid }
+
+    it 'has a proper email error message' do
+      expect(subject.errors.messages[:email]).to(
+        include(I18n.t('edit_user_email_form.errors.email_too_long'))
+      )
+    end
+
+    it 'has no confirmation error message' do
+      expect(subject.errors.messages[:confirmation]).to eq([])
+    end
+  end
+
   context 'when emails match but have invalid format' do
     before { allow(AccountsApi::Accounts).to receive(:user_validations).and_return(true) }
 

--- a/spec/forms/account_details/edit_user_email_form_spec.rb
+++ b/spec/forms/account_details/edit_user_email_form_spec.rb
@@ -110,14 +110,16 @@ describe AccountDetails::EditUserEmailForm, type: :model do
   end
 
   context 'when provided email is too long' do
-    before { allow(AccountsApi::Accounts).to receive(:user_validations).and_return(true) }
-
     let(:email) { "#{'a' * 129}@test.com" }
     let(:confirmation) { "#{'a' * 129}@test.com" }
 
     before { subject.valid? }
 
     it { is_expected.not_to be_valid }
+
+    it 'does not check email uniqueness' do
+      expect(AccountsApi::Accounts).not_to receive(:user_validations)
+    end
 
     it 'has a proper email error message' do
       expect(subject.errors.messages[:email]).to(

--- a/spec/forms/account_details/edit_user_email_form_spec.rb
+++ b/spec/forms/account_details/edit_user_email_form_spec.rb
@@ -110,8 +110,8 @@ describe AccountDetails::EditUserEmailForm, type: :model do
   end
 
   context 'when provided email is too long' do
-    let(:email) { "#{'a' * 129}@test.com" }
-    let(:confirmation) { "#{'a' * 129}@test.com" }
+    let(:email) { "#{'a' * 120}@test.com" }
+    let(:confirmation) { "#{'a' * 120}@test.com" }
 
     before { subject.valid? }
 

--- a/spec/forms/account_details/edit_user_email_form_spec.rb
+++ b/spec/forms/account_details/edit_user_email_form_spec.rb
@@ -126,7 +126,9 @@ describe AccountDetails::EditUserEmailForm, type: :model do
     end
 
     it 'has no confirmation error message' do
-      expect(subject.errors.messages[:confirmation]).to eq([])
+      expect(subject.errors.messages[:confirmation]).to(
+        include(I18n.t('edit_user_email_form.errors.email_too_long'))
+      )
     end
   end
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3387

## Description
<!--- Describe your changes in detail -->
Added email and confirmation length validation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, rspec, cucumber

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5519481/97168874-74a71f00-1789-11eb-8f47-9b1fbfbf6333.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
