### PR TITLE
[CAZB-3387] Fix Update Email 414 error

### DIFF
--- a/app/controllers/account_details/emails_controller.rb
+++ b/app/controllers/account_details/emails_controller.rb
@@ -31,7 +31,7 @@ module AccountDetails
     #
     # ==== Path
     #
-    #    :GET /primary_users/update_email
+    #    :POST /primary_users/update_email
     #
     def update_email
       form = AccountDetails::EditUserEmailForm.new(email_params)

--- a/app/views/account_details/emails/edit_email.html.haml
+++ b/app/views/account_details/emails/edit_email.html.haml
@@ -9,7 +9,7 @@
       - if @errors.present?
         = render 'shared/errors_summary', errors: @errors
 
-      = form_for('primary_user', url: update_email_primary_users_path, method: :get) do |f|
+      = form_for('primary_user', url: update_email_primary_users_path, method: :post) do |f|
         .govuk-form-group{class: ('govuk-form-group--error' if @errors.present?)}
           %fieldset.govuk-fieldset
             %legend.govuk-fieldset__legend.govuk-fieldset__legend--l

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,7 +158,7 @@ Rails.application.routes.draw do
 
         scope controller: 'emails' do
           get :edit_email
-          get :update_email
+          post :update_email
           get :email_sent
           get :resend_email
           get :confirm_email

--- a/spec/requests/account_details/emails/update_email_spec.rb
+++ b/spec/requests/account_details/emails/update_email_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe 'AccountDetails::EmailsController - GET #update_email' do
-  subject { get update_email_primary_users_path, params: params }
+describe 'AccountDetails::EmailsController - POST #update_email' do
+  subject { post update_email_primary_users_path, params: params }
 
   before { sign_in user }
 


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3387?focusedCommentId=249596

## Description
<!--- Describe your changes in detail -->
Previously form parameters were passed as query parameters. When user provided parameters long enough for the whole url to be more that 10240 characters, 414 error was thrown.

Changed `update_email` method from `get` to `post` - parameters are no longer passed through url

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
