### PR TITLE
[CAZB-3506] Switch cache pragma to no-store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
     'X-Content-Type-Options' => 'nosniff',
     'X-XSS-Protection' => '1; mode=block',
     'Strict-Transport-Security' => 'max-age=31536000',
-    'Pragma' => 'no-cache',
+    'Pragma' => 'no-store',
     'X-UA-Compatible' => 'IE=Edge',
     'Access-Control-Allow-Origin' => '*'
   }


### PR DESCRIPTION
Switch cache pragma heading to no-store to prevent stale page content being reloaded on the account management screen.