### PR TITLE
[CAZB-3387] Add `maxlength` attribute to email and confirmation fields

### DIFF
--- a/app/controllers/account_details/emails_controller.rb
+++ b/app/controllers/account_details/emails_controller.rb
@@ -35,7 +35,6 @@ module AccountDetails
     #
     def update_email
       form = AccountDetails::EditUserEmailForm.new(email_params)
-
       if form.valid?
         update_email_and_redirect(form)
       else

--- a/app/views/account_details/emails/edit_email.html.haml
+++ b/app/views/account_details/emails/edit_email.html.haml
@@ -6,15 +6,13 @@
 %main.govuk-main-wrapper#main-content{role: 'main'}
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      - if @errors.present?
-        = render 'shared/errors_summary', errors: @errors
+      = render 'shared/errors_summary', errors: @errors if @errors.present?
 
       = form_for('primary_user', url: update_email_primary_users_path, method: :post) do |f|
         .govuk-form-group{class: ('govuk-form-group--error' if @errors.present?)}
           %fieldset.govuk-fieldset
             %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
-              %h1.govuk-fieldset__heading
-                = title_and_header
+              %h1.govuk-fieldset__heading= title_and_header
 
             .govuk-form-group{class: ('govuk-form-group--error' if @errors[:email].present?)}
               = f.label :email, t('edit_user_email_form.labels.email'), class: 'govuk-label'
@@ -27,6 +25,7 @@
               = f.text_field :email,
                              name: 'email',
                              class: "govuk-input govuk-!-width-two-thirds #{'govuk-input--error' if @errors[:email].present?}",
+                             maxlength: 128,
                              value: @errors.present? ? params[:email] : current_user.email
 
             .govuk-form-group{class: ('govuk-form-group--error' if @errors[:confirmation].present?)}
@@ -40,6 +39,7 @@
               = f.text_field :confirmation,
                              name: 'confirmation',
                              class: "govuk-input govuk-!-width-two-thirds #{'govuk-input--error' if @errors[:confirmation].present?}",
+                             maxlength: 128,
                              value: params[:confirmation]
 
         %p We will send a confirmation email to the new address

--- a/features/account_details/emails.feature
+++ b/features/account_details/emails.feature
@@ -18,10 +18,6 @@ Feature: Email update
       And I press 'Save and continue' button
       Then I should see 'Enter an email address' 3 times
     When I enter change my email page
-      And I fill in email that is too long
-      And I press 'Save and continue' button
-      Then I should see 'Enter an email address that is less than 129 characters' 3 times
-    When I enter change my email page
       And I fill in email with email with invalid format
       And I press 'Save and continue' button
       Then I should see 'Enter email in a valid format' 2 times

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -13,11 +13,6 @@ And('I fill in email with empty string') do
   fill_in('primary_user_email', with: '')
 end
 
-And('I fill in email that is too long') do
-  fill_in('primary_user_email', with: "#{'a' * 120}@test.com")
-  fill_in('primary_user_confirmation', with: "#{'a' * 120}@test.com")
-end
-
 And('I fill in email with email with invalid format') do
   mock_successful_user_validation
   fill_in('primary_user_email', with: 'invalid-email')


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-3387
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
