### PR TITLE
[CAZB-3620] Displays 'Become' instead of 'Became' in the session timed out page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
   fleet_check_form:
     errors:
       confirm_fleet_check: You must choose an answer
-  inactivity_logout: We have signed you out of the business account to keep it secure after it become inactive.
+  inactivity_logout: We have signed you out of the business account to keep it secure after it became inactive.
   input_form:
     errors:
       invalid_format: "%{attribute} is in an invalid format"


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jira Car: https://eaflood.atlassian.net/browse/CAZB-3620

## Description
<!--- Describe your changes in detail -->
Updated text.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
