### PR TITLE
[CAZB-3505] Allow html content to job errors

### DIFF
--- a/app/views/vehicles_management/uploads/_job_errors.html.haml
+++ b/app/views/vehicles_management/uploads/_job_errors.html.haml
@@ -8,4 +8,4 @@
     %ul.govuk-list.govuk-error-summary__list
       - @job_errors.each do |error|
         %li.custom-csv-error
-          = error
+          = error.html_safe


### PR DESCRIPTION
Allow html content to job errors to supply links in error messages