### PR TITLE
[CAZB-3689] Present warning when removing user who created mandates

### DIFF
--- a/app/controllers/users_management/remove_users_controller.rb
+++ b/app/controllers/users_management/remove_users_controller.rb
@@ -21,7 +21,16 @@ module UsersManagement
     #    GET /users/:id/remove
     #
     def remove
-      # renders removal confirmation page
+      @is_mandate_creator = UsersManagement::IsDirectDebitCreator.call(
+        account_id: current_user.account_id,
+        account_user_id: params[:id]
+      )
+
+      return unless @is_mandate_creator
+
+      email_fetcher = UsersManagement::EmailFetcher.new(account_id: current_user.account_id)
+      @user_email = email_fetcher.for_account_user(params[:id])
+      @owner_email = email_fetcher.for_owner
     end
 
     ##

--- a/app/services/users_management/email_fetcher.rb
+++ b/app/services/users_management/email_fetcher.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+##
+# Module used for manage users flow
+#
+module UsersManagement
+  ##
+  # Service responsible for extracting emails for specific account users.
+  #
+  class EmailFetcher
+    ##
+    # Initializer method
+    #
+    # ==== Params
+    #
+    # * +account_id+ - uuid, id of the account
+    def initialize(account_id:)
+      @account_id = account_id
+    end
+
+    # Selects user from the account users list based on the account_user_id parameter.
+    def for_account_user(account_user_id)
+      find_email_for_user_where { |user| user['accountUserId'] == account_user_id }
+    end
+
+    # Selects owner user from the account users list.
+    def for_owner
+      find_email_for_user_where { |user| user['owner'] == true }
+    end
+
+    private
+
+    attr_reader :account_id
+
+    # Performs an API call in order to fetch all account users associated with the provided account.
+    def account_users
+      @account_users ||= AccountsApi::Users.users(account_id: account_id)['users']
+    end
+
+    # Helper method used to fetch specific user based on the provided block condition.
+    def find_email_for_user_where(&block)
+      extract_email(account_users.find(&block))
+    end
+
+    # Helper method used to fetch nullable email attribute.
+    def extract_email(user)
+      user.try(:[], 'email')
+    end
+  end
+end

--- a/app/services/users_management/is_direct_debit_creator.rb
+++ b/app/services/users_management/is_direct_debit_creator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+##
+# Module used for manage users flow
+#
+module UsersManagement
+  ##
+  # Service user to check if the provided user is Direct Debit creator for the provided account.
+  #
+  class IsDirectDebitCreator < BaseService
+    ##
+    # Initializer method
+    #
+    # ==== Params
+    #
+    # * +account_id+ - uuid, id of the account
+    # * +account_user_id+ - uuid, id of the user
+    #
+    def initialize(account_id:, account_user_id:)
+      @account_id = account_id
+      @account_user_id = account_user_id
+    end
+
+    # It calls api and selects only the mandates that were created by the provider account user.
+    # Returns boolean which indicates if there are any mandates created by the user.
+    def call
+      mandates_created_by_user.any?
+    end
+
+    private
+
+    attr_reader :account_id, :account_user_id
+
+    # Performs an api call to fetch direct debit mandates for the provided account id.
+    def mandates
+      @mandates ||= DebitsApi.mandates(account_id: account_id)
+    end
+
+    # Selects mandates created by the provided account user.
+    def mandates_created_by_user
+      mandates.map { |e| e['mandates'] }
+              .flatten
+              .select { |e| e['accountUserId'] == account_user_id }
+    end
+  end
+end

--- a/app/views/users_management/remove_users/remove.haml
+++ b/app/views/users_management/remove_users/remove.haml
@@ -11,6 +11,18 @@
         = render 'shared/error_summary', error_msg_div: '#confirm-remove-user-error', error_msg: alert
 
       %h1.govuk-heading-l= title_and_header
+      - if @is_mandate_creator
+        %p
+          The email address 
+          = @user_email
+          is associated with a Direct Debit mandate.
+          By removing this user, future Direct Debit emails will now go to 
+          = @owner_email
+          and the person making the payment.
+
+        %p
+          If you want another user to receive these emails, you should contact your bank,
+          cancel the Direct Debit and set up a new one.
 
       = form_tag remove_user_path, method: :post do
         .govuk-form-group{class: ('govuk-form-group--error' if alert)}

--- a/features/step_definitions/users_management/remove_user_steps.rb
+++ b/features/step_definitions/users_management/remove_user_steps.rb
@@ -6,6 +6,13 @@ Given('I visit the Manage users page and want to remove user') do
   visit users_path
 end
 
+Given('I visit the Manage users page and want to remove a user who is a mandate creator') do
+  mock_manage_users_api
+  mock_debits
+  login_user(permissions: ['MANAGE_USERS'])
+  visit users_path
+end
+
 Given('I visit the Manage users page and do not want to remove user') do
   mock_manage_users_api
   login_user(permissions: ['MANAGE_USERS'])

--- a/features/users_management/remove_user.feature
+++ b/features/users_management/remove_user.feature
@@ -22,7 +22,17 @@ Feature: Manage user
       And I should be on the Manage users page
       And I should see 'You have successfully removed John Doe from your account.'
 
-  Scenario: Don't wont to remove a user
+  Scenario: Removing a user who is a mandate creator
+    Given I visit the Manage users page and want to remove a user who is a mandate creator
+    Then I press 'Change' link
+      And I should be on the Manage user page
+      And I should see 'Remove' link
+    Then I press 'Remove' link
+      And I should be on the Delete user page
+      And I should see 'anisah@example.com'
+      And I should see 'test@example.com'
+
+  Scenario: Don't want to remove a user
     Given I visit the Manage users page and do not want to remove user
     Then I press 'Change' link
       And I press 'Remove' link
@@ -30,4 +40,3 @@ Feature: Manage user
       And I choose 'No'
     Then I press the Continue
       And I should be on the Manage user page
-

--- a/spec/fixtures/responses/debits/mandates.json
+++ b/spec/fixtures/responses/debits/mandates.json
@@ -14,16 +14,19 @@
         {
           "id": "55f9d425-f60b-4919-9020-b6e48d641ba4",
           "status": "active",
+          "accountUserId": "61c193b6-30b4-4fef-831f-7af7513e40e6",
           "created": "2020-04-30T08:08:31"
         },
         {
           "id": "09b72307-e56a-4b61-802a-03eee58748ba",
           "status": "failed",
+          "accountUserId": "6ffc41fd-ff2d-4cc1-a2a2-90006ae26446",
           "created": "2020-04-30T08:08:31"
         },
         {
           "id": "45725067-ae01-4c68-9884-8aac0f5c320b",
           "status": "cancelled",
+          "accountUserId": "51862a1f-7a9c-4389-9a0f-8eb0296e2b3b",
           "created": "2020-04-30T08:08:31"
         }
       ]

--- a/spec/requests/users_management/remove_users/remove_spec.rb
+++ b/spec/requests/users_management/remove_users/remove_spec.rb
@@ -9,14 +9,62 @@ describe 'UsersManagement::RemoveUsersController - GET #remove' do
     context 'with edit user data in session' do
       before { add_to_session(edit_user: { name: 'John Doe' }) }
 
-      context 'when user is exist in db' do
+      context 'when user exists in the db' do
         before do
           sign_in manage_users_user
           mock_user_details
+          allow(UsersManagement::IsDirectDebitCreator).to receive(:call).and_return(is_creator)
+          allow(UsersManagement::EmailFetcher).to receive(:new).and_return(
+            instance_double('UsersManagement::EmailFetcher',
+                            for_account_user: 'user@email.com',
+                            for_owner: 'owner@email.com')
+          )
         end
 
-        it 'renders the view' do
-          expect(subject).to render_template(:remove)
+        context 'when user is a mandate creator' do
+          let(:is_creator) { true }
+
+          it 'assigns @is_mandate_creator variable' do
+            subject
+            expect(assigns(:is_mandate_creator)).to eq true
+          end
+
+          it 'assigns @user_email variable' do
+            subject
+            expect(assigns(:user_email)).to eq 'user@email.com'
+          end
+
+          it 'assigns @user_email variable' do
+            subject
+            expect(assigns(:owner_email)).to eq 'owner@email.com'
+          end
+
+          it 'renders the view' do
+            expect(subject).to render_template(:remove)
+          end
+        end
+
+        context 'when user is not a mandate creator' do
+          let(:is_creator) { false }
+
+          it 'assigns @is_mandate_creator variable' do
+            subject
+            expect(assigns(:is_mandate_creator)).to eq false
+          end
+
+          it 'does not assign @user_email variable' do
+            subject
+            expect(assigns(:user_email)).to eq nil
+          end
+
+          it 'does not assign @user_email variable' do
+            subject
+            expect(assigns(:owner_email)).to eq nil
+          end
+
+          it 'renders the view' do
+            expect(subject).to render_template(:remove)
+          end
         end
       end
 

--- a/spec/services/users_management/email_fetcher_spec.rb
+++ b/spec/services/users_management/email_fetcher_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UsersManagement::EmailFetcher do
+  subject { described_class.new(account_id: account_id) }
+
+  let(:account_id) { @uuid }
+  let(:existing_user_id) { '5cd7441d-766f-48ff-b8ad-1809586fea37' }
+  let(:non_existing_user_id) { 'ee369462-63fe-4869-8ad9-0f02d03da1d6' }
+
+  before { mock_users }
+
+  describe '#for_account_user' do
+    it 'calls AccountsApi with proper params' do
+      subject.for_account_user(account_id)
+      expect(AccountsApi::Users).to have_received(:users).with(account_id: account_id)
+    end
+
+    it 'returns email for existing user' do
+      expect(subject.for_account_user(existing_user_id)).to eq('john@example.com')
+    end
+
+    it 'returns nil for non existing user' do
+      expect(subject.for_account_user(non_existing_user_id)).to eq(nil)
+    end
+  end
+
+  describe '#for_owner' do
+    it 'calls AccountsApi with proper params' do
+      subject.for_owner
+      expect(AccountsApi::Users).to have_received(:users).with(account_id: account_id)
+    end
+
+    it 'returns email for owner' do
+      expect(subject.for_owner).to eq('test@example.com')
+    end
+  end
+end

--- a/spec/services/users_management/is_direct_debit_creator_spec.rb
+++ b/spec/services/users_management/is_direct_debit_creator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UsersManagement::IsDirectDebitCreator do
+  subject { described_class.call(account_id: account_id, account_user_id: account_user_id) }
+
+  let(:account_id) { @uuid }
+  let(:existing_mandate_user_id) { '61c193b6-30b4-4fef-831f-7af7513e40e6' }
+  let(:non_existing_mandate_user_id) { 'c72d54fd-e1f9-40d6-899d-d4dff4fc37bb' }
+
+  before { mock_debits }
+
+  describe '#call' do
+    context 'when user is mandate creator' do
+      let(:account_user_id) { existing_mandate_user_id }
+
+      it 'returns true' do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context 'when user is not a mandate creator' do
+      let(:account_user_id) { non_existing_mandate_user_id }
+
+      it 'return false' do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Link to JIRA Card: https://eaflood.atlassian.net/browse/CAZB-3689

## Description
<!--- Describe your changes in detail -->
* When removing a user from the Account, an API call is being performed in order to get mandates associated with the account. If a user who is being removed created any mandates, an additional warning is being displayed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Create an account owner and a user with direct debit mandates management permission.
* Create a mandate using the secondary user account
* Try to remove a secondary user using an account owner account
* When removing the secondary user, you should see a warning

## Screenshots (if appropriate):
<img width="765" alt="Screenshot 2021-01-21 at 12 11 25" src="https://user-images.githubusercontent.com/4506633/105374226-c08e2680-5c07-11eb-91d4-25cee0cd2c8c.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
