### PR TITLE
[CAZB-4178] Hide DD button if all DD CAZes are disabled

### DIFF
--- a/app/api_wrappers/debits_api.rb
+++ b/app/api_wrappers/debits_api.rb
@@ -90,7 +90,6 @@ class DebitsApi < PaymentsApi
     #     * +status+ - string, status of the mandate eg. 'active'
     #
     def mandates(account_id:)
-      log_action('Getting mandates')
       request(:get, "/payments/accounts/#{account_id}/direct-debit-mandates")['cleanAirZones']
     end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -24,6 +24,7 @@ class DashboardController < ApplicationController
   #
   def index
     @vehicles_count = current_user.fleet.total_vehicles_count
+    @all_dd_cazes_enabled = all_dd_cazes_enabled
     @mandates_present = check_mandates
     account_users = load_account_users
     @users_present = check_users(account_users)
@@ -43,6 +44,13 @@ class DashboardController < ApplicationController
     else
       false
     end
+  end
+
+  # Calls api to check if at least one direct debit caz is enabled
+  def all_dd_cazes_enabled
+    Rails.logger.info "[#{self.class.name}] Getting enabled direct debit clean air zones"
+    DebitsApi.mandates(account_id: current_user.account_id)
+             .select { |caz| caz['directDebitEnabled'] == true }.present?
   end
 
   # Loads account users

--- a/app/controllers/direct_debits/debits_controller.rb
+++ b/app/controllers/direct_debits/debits_controller.rb
@@ -103,7 +103,9 @@ module DirectDebits
 
     ##
     # Renders a selector to add a new mandate.
-    # If there is no possible new mandates, redirects to the #index
+    # If there is no possible to create a new mandate and no active mandates, redirects to the
+    # {rdoc-refDashboardController:index}
+    # If there is no possible to create a new mandate and some active mandates, redirects to the {rdoc-ref:index}
     #
     # ==== Path
     #
@@ -111,6 +113,8 @@ module DirectDebits
     #
     def set_up
       @zones = @debit.inactive_mandates
+
+      return redirect_to dashboard_path if @zones.empty? && @debit.active_mandates.empty?
 
       redirect_to debits_path if @zones.empty?
     end

--- a/app/models/direct_debits/debit.rb
+++ b/app/models/direct_debits/debit.rb
@@ -33,11 +33,13 @@ module DirectDebits
 
     # Returns an array of associated DirectDebits::Mandate instances in `active` or `pending_submission` statuses
     def active_mandates
+      Rails.logger.info "[#{self.class.name}] Getting active mandates"
       mandates.select { |mandate| select_active_statuses(mandate.status) }
     end
 
     # Returns an array of associated DirectDebits::Mandate instances without `active` or `pending_submission` statuses
     def inactive_mandates
+      Rails.logger.info "[#{self.class.name}] Getting inactive mandates"
       mandates.reject { |mandate| select_active_statuses(mandate.status) }
     end
 

--- a/app/views/dashboard/_direct_debit.html.haml
+++ b/app/views/dashboard/_direct_debit.html.haml
@@ -10,5 +10,3 @@
         = link_to('Pay by bank account', debits_path, id: 'direct-debit')
     %p.govuk-body
       Use your bank details to pay a charge as an alternative to paying by card.
-
-

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -26,7 +26,7 @@
 
   .govuk-grid-row
     = render 'manage_vehicles' if allow_manage_vehicles?
-    = render 'direct_debit' if direct_debits_enabled? && allow_manage_mandates?
+    = render 'direct_debit' if direct_debits_enabled? && allow_manage_mandates? && @all_dd_cazes_enabled
     = render 'manage_users' if allow_manage_users?
     - if !disable_payment_features
       = render 'make_payment' if allow_make_payments? && @vehicles_count >= 2

--- a/features/step_definitions/account_details/emails_steps.rb
+++ b/features/step_definitions/account_details/emails_steps.rb
@@ -45,6 +45,7 @@ When('I visit the Confirm email update page') do
   mock_vehicles_in_fleet
   mock_users
   mock_direct_debit_disabled
+  mock_debits
   mock_account_details
   mock_clean_air_zones
   mock_payment_history
@@ -58,6 +59,7 @@ When('I visit the Confirm email update page when is not logged in') do
   mock_vehicles_in_fleet
   mock_users
   mock_clean_air_zones
+  mock_debits
 
   allow(AccountsApi::Auth).to receive(:confirm_email).and_return('john.doe@example.com')
   allow(AccountsApi::Auth)

--- a/features/step_definitions/account_details/non_primary_user_steps.rb
+++ b/features/step_definitions/account_details/non_primary_user_steps.rb
@@ -6,6 +6,7 @@ Given('I visit non-primary user Account Details page') do
   mock_user_details
   mock_account_details
   mock_clean_air_zones
+  mock_debits
 
   login_user(permissions: ['MANAGE_USERS'])
   visit non_primary_users_account_details_path

--- a/features/step_definitions/payment_history_steps.rb
+++ b/features/step_definitions/payment_history_steps.rb
@@ -3,6 +3,7 @@
 Given('I visit the Company payment history page') do
   mock_api_on_payment_history
   mock_clean_air_zones
+  mock_debits
   login_user(permissions: %w[VIEW_PAYMENTS MAKE_PAYMENTS])
   visit payment_history_path
 end
@@ -92,6 +93,7 @@ def mock_api_and_sign_in_user
   mock_api_on_payment_history
   mock_payment_details_history
   mock_clean_air_zones
+  mock_debits
   login_user(permissions: %w[VIEW_PAYMENTS MAKE_PAYMENTS])
 end
 

--- a/features/step_definitions/vehicles_management/fleets_steps.rb
+++ b/features/step_definitions/vehicles_management/fleets_steps.rb
@@ -5,6 +5,7 @@ Given('I have no vehicles in my fleet') do
   mock_users
   mock_empty_fleet
   mock_clean_air_zones
+  mock_debits
   mock_payment_history
 end
 
@@ -13,6 +14,7 @@ Given('I have no vehicles in my fleet and visit the manage vehicles page') do
   mock_empty_fleet
   mock_users
   mock_clean_air_zones
+  mock_debits
   mock_payment_history
   login_user({ permissions: 'MANAGE_VEHICLES' })
   visit fleets_path
@@ -46,6 +48,7 @@ When('I visit the submission method page') do
   mock_vehicles_in_fleet
   mock_users
   mock_clean_air_zones
+  mock_debits
   mock_payment_history
 
   login_user({ permissions: 'MANAGE_VEHICLES' })
@@ -78,6 +81,7 @@ When('I have vehicles in my fleet') do
   mock_clean_air_zones
   mock_vehicles_in_fleet
   mock_chargeable_vehicles
+  mock_debits
   mock_caz_mandates
   mock_direct_debit_enabled
   mock_payment_history
@@ -89,16 +93,18 @@ When('I have vehicles in my fleet and only one CAZ is available') do
   mock_one_clean_air_zones
   mock_vehicles_in_fleet
   mock_chargeable_vehicles
-  mock_caz_mandates
   mock_direct_debit_enabled
+  mock_debits
+  mock_caz_mandates
   mock_payment_history
 end
 
 When('I have undetermined vehicles in my fleet') do
   mock_clean_air_zones
   mock_undetermined_vehicles_in_fleet
-  mock_caz_mandates
   mock_direct_debit_enabled
+  mock_debits
+  mock_caz_mandates
   mock_users
   mock_payment_history
 end

--- a/features/step_definitions/vehicles_management/uploads_step.rb
+++ b/features/step_definitions/vehicles_management/uploads_step.rb
@@ -33,6 +33,7 @@ end
 When('I am on the processing page') do
   mock_actual_account_name
   mock_clean_air_zones
+  mock_debits
   mock_payment_history
   mock_processing_page(large_fleet: true)
 end
@@ -40,6 +41,7 @@ end
 When('I am on the processing page and number of vehicles less than the threshold') do
   mock_actual_account_name
   mock_clean_air_zones
+  mock_debits
   mock_payment_history
   mock_processing_page(large_fleet: false)
 end

--- a/features/step_definitions/vehicles_management/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_management/vehicles_steps.rb
@@ -5,6 +5,7 @@ When('I visit the enter details page') do
   mock_users
   mock_actual_account_name
   mock_clean_air_zones
+  mock_debits
   login_user(permissions: 'MANAGE_VEHICLES')
   visit enter_details_vehicles_path
 end

--- a/spec/requests/dashboard_controller_spec.rb
+++ b/spec/requests/dashboard_controller_spec.rb
@@ -101,6 +101,7 @@ describe DashboardController, type: :request do
         mock_users
         mock_actual_account_name
         mock_clean_air_zones
+        mock_debits
         mock_payment_history
         sign_in create_user(permissions: [], days_to_password_expiry: 8)
         subject
@@ -123,6 +124,7 @@ describe DashboardController, type: :request do
           mock_actual_account_name
           mock_clean_air_zones
           mock_payment_history
+          mock_debits
           sign_in create_user(permissions: ['VIEW_PAYMENTS'], days_to_password_expiry: 8)
           subject
         end
@@ -138,6 +140,7 @@ describe DashboardController, type: :request do
           mock_users
           mock_actual_account_name
           mock_clean_air_zones
+          mock_debits
           mock_empty_payment_history
           sign_in create_user(permissions: ['VIEW_PAYMENTS'], days_to_password_expiry: 8)
           subject
@@ -157,6 +160,7 @@ describe DashboardController, type: :request do
           mock_actual_account_name
           mock_clean_air_zones
           mock_payment_history
+          mock_debits
           sign_in create_user(permissions: ['MAKE_PAYMENTS'], days_to_password_expiry: 8)
           subject
         end
@@ -173,6 +177,7 @@ describe DashboardController, type: :request do
           mock_actual_account_name
           mock_clean_air_zones
           mock_empty_payment_history
+          mock_debits
           sign_in create_user(permissions: ['MAKE_PAYMENTS'], days_to_password_expiry: 8)
           subject
         end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/CAZB-4178
```
Edmond Chhung  2:49 PM
i found an issue with  https://eaflood.atlassian.net/browse/CAZB-4178
if you disable both CAZ's and the user isnt part of the beta group
the link is still there
```
## Description
<!--- Describe your changes in detail -->
Check if at leas one DD Caz is enabled.
Fixed loop if there zero active and invactive cazes on set_up page
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
