### PR TITLE
[CAZB-4299|CAZB-4248] Update DVLA number plate regex validation

### DIFF
--- a/app/controllers/vehicles_management/vehicles_controller.rb
+++ b/app/controllers/vehicles_management/vehicles_controller.rb
@@ -45,7 +45,7 @@ module VehiclesManagement
     #
     def submit_details
       form = VrnForm.new(params[:vrn])
-      session[:vrn] = form.vrn
+
       determinate_next_step(form)
     end
 
@@ -239,8 +239,10 @@ module VehiclesManagement
     def determinate_next_step(form)
       if form.valid?
         redirect_to details_vehicles_path
+        session[:vrn] = form.vrn
       else
         @errors = form.errors.messages
+        session[:vrn] = params[:vrn]
         render :enter_details
       end
     end

--- a/app/forms/vrn_form.rb
+++ b/app/forms/vrn_form.rb
@@ -23,7 +23,7 @@ class VrnForm < BaseForm
   #
   # * +vrn+ - string, eg. 'CU57ABC'
   def initialize(vrn)
-    @vrn = vrn&.upcase&.delete(' ')
+    @vrn = vrn&.upcase&.delete(' ')&.gsub(/^0+/, '')
   end
 
   private
@@ -32,52 +32,20 @@ class VrnForm < BaseForm
   def validate_format
     return if FORMAT_REGEXPS.any? do |reg|
       reg.match(vrn).present?
-    end && no_leading_zeros?
+    end
 
     errors.add(:vrn, I18n.t('vrn_form.errors.vrn_invalid'))
   end
 
-  # Checks if VRN starts with '0'
-  def no_leading_zeros?
-    !vrn.starts_with?('0')
-  end
-
   # Possible vrn formats
   FORMAT_REGEXPS = [
-    /^[A-Z]{3}[0-9]{3}$/, # AAA999
-    /^[A-Z][0-9]{3}[A-Z]{3}$/, # A999AAA
-    /^[A-Z]{3}[0-9]{3}[A-Z]$/, # AAA999A
-    /^[A-Z]{3}[0-9]{4}$/, # AAA9999
-    /^[A-Z]{2}[0-9]{2}[A-Z]{3}$/, # AA99AAA
-    /^[0-9]{4}[A-Z]{3}$/, # 9999AAA
-    /^[A-Z][0-9]$/, # A9
-    /^[0-9][A-Z]$/, # 9A
-    /^[A-Z]{2}[0-9]$/, # AA9
-    /^[A-Z][0-9]{2}$/, # A99
-    /^[0-9][A-Z]{2}$/, # 9AA
-    /^[0-9]{2}[A-Z]$/, # 99A
-    /^[A-Z]{3}[0-9]$/, # AAA9
-    /^[A-Z][0-9]{3}$/, # A999
-    /^[A-Z]{2}[0-9]{2}$/, # AA99
-    /^[0-9][A-Z]{3}$/, # 9AAA
-    /^[0-9]{2}[A-Z]{2}$/, # 99AA
-    /^[0-9]{3}[A-Z]$/, # 999A
-    /^[A-Z][0-9][A-Z]{3}$/, # A9AAA
-    /^[A-Z]{3}[0-9][A-Z]$/, # AAA9A
-    /^[A-Z]{3}[0-9]{2}$/, # AAA99
-    /^[A-Z]{2}[0-9]{3}$/, # AA999
-    /^[0-9]{2}[A-Z]{3}$/, # 99AAA
-    /^[0-9]{3}[A-Z]{2}$/, # 999AA
-    /^[0-9]{4}[A-Z]$/, # 9999A
-    /^[A-Z][0-9]{4}$/, # A9999
-    /^[A-Z][0-9]{2}[A-Z]{3}$/, # A99AAA
-    /^[A-Z]{3}[0-9]{2}[A-Z]$/, # AAA99A
-    /^[0-9]{3}[A-Z]{3}$/, # 999AAA
-    /^[A-Z]{2}[0-9]{4}$/, # AA9999
-    /^[0-9]{4}[A-Z]{2}$/, # 9999AA
-
-    # The following regex is technically not valid, but is considered as valid
-    # due to the requirement which forces users not to include leading zeros.
-    /^[A-Z]{2,3}$/ # AA, AAA
+    /^[A-Za-z]{1,2}[0-9]{1,4}$/,
+    /^[A-Za-z]{3}[0-9]{1,3}$/,
+    /^[1-9][0-9]{0,2}[A-Za-z]{3}$/,
+    /^[1-9][0-9]{0,3}[A-Za-z]{1,2}$/,
+    /^[A-Za-z]{3}[0-9]{1,3}[A-Za-z]$/,
+    /^[A-Za-z][0-9]{1,3}[A-Za-z]{3}$/,
+    /^[A-Za-z]{2}[0-9]{2}[A-Za-z]{3}$/,
+    /^[A-Za-z]{3}[0-9]{4}$/
   ].freeze
 end

--- a/features/step_definitions/vehicles_management/vehicles_steps.rb
+++ b/features/step_definitions/vehicles_management/vehicles_steps.rb
@@ -15,6 +15,15 @@ When('I enter vrn') do
   fill_in('vrn', with: 'CU57ABC')
 end
 
+When('I enter valid vrn with leading zeros') do
+  mock_vehicle_details
+  fill_in('vrn', with: '00CU57ABC')
+end
+
+When('I enter invalid vrn with leading zeros') do
+  fill_in('vrn', with: '00AB')
+end
+
 When('I enter exempt vrn') do
   mock_exempt_vehicle_details
   fill_in('vrn', with: 'CU57ABC')

--- a/features/vehicles_management/vehicles.feature
+++ b/features/vehicles_management/vehicles.feature
@@ -22,6 +22,20 @@ Feature: Vehicles
       And I press the Continue
     Then I should see 'Enter the number plate of the vehicle' 3 times
 
+  Scenario: Adding invalid vrn with leading zeros
+    When I visit the enter details page
+      And I enter invalid vrn with leading zeros
+      And I press the Continue
+    Then I should see 'Enter the number plate of the vehicle in a valid format' 2 times
+      And I should see '00AB' as 'vrn' value
+
+  Scenario: Adding valid vrn with leading zeros
+    When I visit the enter details page
+      And I enter valid vrn with leading zeros
+      And I press the Continue
+    Then I should be on the details page
+      And I should see 'Number plate CU57ABC'
+
   Scenario: Adding the exempt vehicle
     When I visit the enter details page
       And I enter exempt vrn

--- a/spec/forms/vrn_form_spec.rb
+++ b/spec/forms/vrn_form_spec.rb
@@ -10,10 +10,10 @@ describe VrnForm, type: :model do
   it { is_expected.to be_valid }
   it { expect(subject.vrn).to eq(vrn) }
 
-  context 'when vrn includes spaces and small letters' do
-    let(:vrn) { 'AbC 12 3' }
+  context 'when vrn includes spaces and small letters and leading zeros' do
+    let(:vrn) { '00AbC 12 3' }
 
-    it 'removes spaces and upcases vrn' do
+    it 'removes spaces and leading zeros and upcases the vrn' do
       expect(subject.vrn).to eq('ABC123')
     end
   end
@@ -42,9 +42,13 @@ describe VrnForm, type: :model do
     it_behaves_like 'an invalid VrnForm', I18n.t('vrn_form.errors.vrn_invalid')
   end
 
-  context 'when VRN starts with 0' do
-    let(:vrn) { '00SGL6' }
+  context 'when VRN starts with 0 and is with 0 stripped' do
+    let(:vrn) { '009999A' }
 
-    it_behaves_like 'an invalid VrnForm', I18n.t('vrn_form.errors.vrn_invalid')
+    it { is_expected.to be_valid }
+
+    it 'removes leading zeros and upcases the vrn' do
+      expect(subject.vrn).to eq('9999A')
+    end
   end
 end


### PR DESCRIPTION
<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
Update DVLA number plate regex validation and strip down leading zeros for UK number plates
Jira Cards: 
https://eaflood.atlassian.net/browse/CAZB-4299
https://eaflood.atlassian.net/browse/CAZB-4248
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
