### PR TITLE
[CAZB-4953] Update error positioning

### DIFF
--- a/app/views/relevant_portal/what_would_you_like_to_do.html.haml
+++ b/app/views/relevant_portal/what_would_you_like_to_do.html.haml
@@ -4,9 +4,9 @@
 = render 'shared/js_back_link'
 
 %main.govuk-main-wrapper#main-content{role: 'main'}
+  
   .govuk-grid-row
     .govuk-grid-column-two-thirds
-      %h1.govuk-heading-xl= title_and_header
 
       - if alert
         = render 'shared/error_summary',
@@ -16,8 +16,7 @@
       = form_for('relevant_portal', url: what_would_you_like_to_do_path, method: :post) do |f|
         .govuk-form-group{class: ('govuk-form-group--error' if alert.present?)}
           %fieldset.govuk-fieldset
-            %legend.govuk-visually-hidden What would you like to do
-
+            %legend.govuk-heading-xl= title_and_header
             - if alert.present?
               %span#check_vehicle_option-error.govuk-error-message
                 %span.govuk-visually-hidden Error:


### PR DESCRIPTION
## Motivation and Context

https://eaflood.atlassian.net/browse/CAZB-4953

To abide by GDS patterns (see https://design-system.service.gov.uk/components/radios/error/index.html), the error summary position is being updated on the "What would you like to do?" triaging page. To support accessibility, the h1 in this instance is being converted to a styled field legend.

## Description
Error position updated and switched H1 to a style legend (for accessibility purposes) in the fieldset

## How Has This Been Tested?
Visual checks performed with HTML inspection on the fieldset construction

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6195772/119883445-76a3ad00-bf27-11eb-8b67-19f42941e2c1.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of develop) --->
<!--- - bug/... for bug (branched of develop) --->
